### PR TITLE
feat: update Pi configuration and service deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dot_config/qtile/modules/keys/apps.py
 dot_config/qtile/modules/widgets/weather.py
 dot_config/qtile-wl/json/settings.json
 .pi/
+.worktrees/

--- a/dot_config/systemd/user/minikube.service
+++ b/dot_config/systemd/user/minikube.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Minikube Cluster (prod)
+After=network.target
+StartLimitIntervalSec=0
+
+[Service]
+Type=simple
+Environment=MINIKUBE_HOME=%h/.local/share/minikube
+ExecStart=/bin/bash %h/prjs/arc/scripts/minikube/start.sh
+ExecStop=/bin/bash -c 'source %h/prjs/arc/runners/qtile/defaults.sh && minikube stop -p "$DEFAULT_MINIKUBE_PROFILE"'
+Restart=always
+RestartSec=30
+WorkingDirectory=%h
+StandardOutput=journal
+
+[Install]
+WantedBy=default.target

--- a/dot_pi/agent/AGENTS.md
+++ b/dot_pi/agent/AGENTS.md
@@ -8,3 +8,10 @@
 - **Subagents (Implementation & Work)**:
   - Role: Execution and Workers.
   - All file changes, coding, test execution, debugging, and mechanical tasks are carried out by subagents running on `gpt-5.6-luna:high`.
+
+## Fallback Policy
+
+- When GPT / OpenAI Codex models (Sol or Luna) are unavailable, hit rate limits, or exhaust usage quotas:
+  - Fall back to `google/gemini-3.8-flash` with `high` thinking.
+  - Subagents automatically fall back to `google/gemini-3.8-flash:high` to complete delegated work.
+  - The main session switches to `gemini-3.8-flash:high` for continued planning.

--- a/dot_pi/agent/AGENTS.md
+++ b/dot_pi/agent/AGENTS.md
@@ -1,0 +1,10 @@
+# Global Agent Operating Instructions
+
+## Role Separation
+
+- **Main Session (Planning Only)**:
+  - Role: Architect, Planner, and Supervisor.
+  - The main session does not perform direct implementation or write code/tests. It designs the plan, frames the requirements, evaluates trade-offs, and delegates work.
+- **Subagents (Implementation & Work)**:
+  - Role: Execution and Workers.
+  - All file changes, coding, test execution, debugging, and mechanical tasks are carried out by subagents running on `gpt-5.6-luna:high`.

--- a/dot_pi/agent/APPEND_SYSTEM.md
+++ b/dot_pi/agent/APPEND_SYSTEM.md
@@ -6,3 +6,7 @@
 - **Subagents (Execution & Work)**:
   - All hands-on coding, file edits, testing, tool-heavy execution, and debugging must be delegated to subagents.
   - Subagents run on `openai-codex/gpt-5.6-luna:high` (as configured in settings).
+- **Fallback Rule (When GPT / Codex is Unavailable or Quota Exhausted)**:
+  - If `gpt-5.6-sol` or `gpt-5.6-luna` reaches usage limits, rate limits, or is unavailable, immediately fall back to `google/gemini-3.8-flash` (thinking: `high`).
+  - For the main session: switch planning to `gemini-3.8-flash:high` (or prompt `/model gemini-3.8-flash:high`).
+  - For subagents: use `google/gemini-3.8-flash:high` as the automatic fallback model so execution continues without interruption.

--- a/dot_pi/agent/APPEND_SYSTEM.md
+++ b/dot_pi/agent/APPEND_SYSTEM.md
@@ -1,0 +1,8 @@
+# Operating Mode: Orchestration & Delegation
+
+- **Main Session (Planning & Supervision Only)**:
+  - The main session runs on `gpt-5.6-sol` (thinking: `high`) and is strictly reserved for planning, architecture, task breakdown, code review synthesis, and orchestration.
+  - Do NOT perform direct implementation, file modifications, test runs, or heavy execution work in the main session.
+- **Subagents (Execution & Work)**:
+  - All hands-on coding, file edits, testing, tool-heavy execution, and debugging must be delegated to subagents.
+  - Subagents run on `openai-codex/gpt-5.6-luna:high` (as configured in settings).

--- a/dot_pi/agent/extensions/claude-status.ts
+++ b/dot_pi/agent/extensions/claude-status.ts
@@ -182,8 +182,7 @@ function parseGeminiUsage(value: unknown, activeModel: string): UsageLimit[] {
 	});
 	const candidates = matching.length > 0 ? matching : buckets;
 	const bucket = candidates.reduce((lowest, candidate) =>
-		(candidate.remainingFraction as number) <
-		(lowest.remainingFraction as number)
+		(candidate.remainingFraction as number) < (lowest.remainingFraction as number)
 			? candidate
 			: lowest,
 	);
@@ -192,9 +191,7 @@ function parseGeminiUsage(value: unknown, activeModel: string): UsageLimit[] {
 			windows: [
 				{
 					label: "d",
-					remainingPercent: clampPercent(
-						(bucket.remainingFraction as number) * 100,
-					),
+					remainingPercent: clampPercent((bucket.remainingFraction as number) * 100),
 					resetsAt: parseResetAt(bucket.resetTime),
 				},
 			],
@@ -223,6 +220,8 @@ export default function (pi: ExtensionAPI) {
 	let providerUsage: UsageLimit[] = [];
 	let gitDiff = "";
 	let refreshProviderUsage: ((ctx: ExtensionContext) => void) | undefined;
+	let activeModel: ExtensionContext["model"];
+	let footerTui: RenderRequester | undefined;
 	let usageRequest: Promise<void> | undefined;
 	let usageRequestProvider: string | undefined;
 	let geminiProjectId: string | undefined;
@@ -298,8 +297,7 @@ export default function (pi: ExtensionAPI) {
 	async function fetchCodexUsage(
 		ctx: ExtensionContext,
 	): Promise<UsageLimit[] | undefined> {
-		const providerAuth =
-			await ctx.modelRegistry.getProviderAuth("openai-codex");
+		const providerAuth = await ctx.modelRegistry.getProviderAuth("openai-codex");
 		const accessToken = providerAuth?.auth.apiKey;
 		if (!accessToken) return [];
 		const accountId = extractAccountId(accessToken);
@@ -396,24 +394,18 @@ export default function (pi: ExtensionAPI) {
 		};
 		geminiProjectId ??= env.GOOGLE_CLOUD_PROJECT || env.GOOGLE_CLOUD_PROJECT_ID;
 		if (!geminiProjectId) {
-			const setup = await fetchJson(
-				`${GEMINI_CODE_ASSIST_URL}:loadCodeAssist`,
-				{
-					method: "POST",
-					headers,
-					body: JSON.stringify({
-						metadata: {
-							ideType: "IDE_UNSPECIFIED",
-							platform: "PLATFORM_UNSPECIFIED",
-							pluginType: "GEMINI",
-						},
-					}),
-				},
-			);
-			if (
-				isRecord(setup) &&
-				typeof setup.cloudaicompanionProject === "string"
-			) {
+			const setup = await fetchJson(`${GEMINI_CODE_ASSIST_URL}:loadCodeAssist`, {
+				method: "POST",
+				headers,
+				body: JSON.stringify({
+					metadata: {
+						ideType: "IDE_UNSPECIFIED",
+						platform: "PLATFORM_UNSPECIFIED",
+						pluginType: "GEMINI",
+					},
+				}),
+			});
+			if (isRecord(setup) && typeof setup.cloudaicompanionProject === "string") {
 				geminiProjectId = setup.cloudaicompanionProject;
 			}
 		}
@@ -554,17 +546,24 @@ export default function (pi: ExtensionAPI) {
 		return "?m";
 	}
 
-	pi.on("model_select", (_event, ctx) => {
+	pi.on("model_select", (event, ctx) => {
+		// The context captured by the footer at session_start can retain the
+		// previous model. Use the event model so model-specific values such as
+		// contextWindow update immediately after a model switch.
+		activeModel = event.model;
+		footerTui?.requestRender();
 		refreshProviderUsage?.(ctx);
 	});
 
 	pi.on("session_start", (_event, ctx) => {
+		activeModel = ctx.model;
 		let diffTimer: ReturnType<typeof setInterval> | undefined;
 		let resetTimer: ReturnType<typeof setInterval> | undefined;
 		let startupUsageTimer: ReturnType<typeof setTimeout> | undefined;
 		let usageTimer: ReturnType<typeof setInterval> | undefined;
 
 		ctx.ui.setFooter((tui, _theme, footerData) => {
+			footerTui = tui;
 			updateGitDiff(ctx.cwd, tui);
 			diffTimer = setInterval(() => {
 				updateGitDiff(ctx.cwd, tui);
@@ -588,6 +587,7 @@ export default function (pi: ExtensionAPI) {
 			return {
 				dispose: () => {
 					unsubBranch();
+					if (footerTui === tui) footerTui = undefined;
 					if (diffTimer) clearInterval(diffTimer);
 					if (resetTimer) clearInterval(resetTimer);
 					if (startupUsageTimer) clearTimeout(startupUsageTimer);
@@ -657,16 +657,14 @@ export default function (pi: ExtensionAPI) {
 						blue = "\x1b[34m";
 
 					// Model & Effort
-					const model = ctx.model?.id || "no-model";
-					const effort =
-						ctx.thinkingLevel || env.PI_REASONING_LEVEL || "default";
+					const model = activeModel ?? ctx.model;
+					const modelId = model?.id || "no-model";
+					const effort = ctx.thinkingLevel || env.PI_REASONING_LEVEL || "default";
 
 					if (effort && effort !== "off") {
-						parts.push(
-							`${bold}${cyan}${model}${reset}${dim}[${effort}]${reset}`,
-						);
+						parts.push(`${bold}${cyan}${modelId}${reset}${dim}[${effort}]${reset}`);
 					} else {
-						parts.push(`${bold}${cyan}${model}${reset}`);
+						parts.push(`${bold}${cyan}${modelId}${reset}`);
 					}
 
 					// Tokens
@@ -677,7 +675,7 @@ export default function (pi: ExtensionAPI) {
 					parts.push(`${dim}${tokensStr}${reset}`);
 
 					// Context
-					const contextWindow = ctx.model?.contextWindow || 0;
+					const contextWindow = model?.contextWindow || 0;
 					if (contextWindow > 0) {
 						// Using context limit calculation
 						const pct = Math.round((latestPromptTokens / contextWindow) * 100);
@@ -692,9 +690,7 @@ export default function (pi: ExtensionAPI) {
 						};
 
 						// Adding a space before the slash for readability
-						parts.push(
-							`ctx:${color}${pct}%${reset} / ${fmtMax(contextWindow)}`,
-						);
+						parts.push(`ctx:${color}${pct}%${reset} / ${fmtMax(contextWindow)}`);
 					}
 
 					// Provider subscription limits
@@ -703,13 +699,10 @@ export default function (pi: ExtensionAPI) {
 						const limitName = formatLimitName(limit.name);
 						for (const window of limit.windows) {
 							const remaining = Math.round(window.remainingPercent);
-							const color =
-								remaining <= 20 ? red : remaining <= 50 ? yellow : green;
+							const color = remaining <= 20 ? red : remaining <= 50 ? yellow : green;
 							const prefix = limitName ? `${limitName}/` : "";
 							const resetTimer = formatResetTimer(window.resetsAt);
-							const resetText = resetTimer
-								? `${dim}↻${resetTimer}${reset}`
-								: "";
+							const resetText = resetTimer ? `${dim}↻${resetTimer}${reset}` : "";
 							limitParts.push(
 								`${prefix}${window.label}:${color}${remaining}%${reset}${resetText}`,
 							);

--- a/dot_pi/agent/models.json
+++ b/dot_pi/agent/models.json
@@ -1,0 +1,17 @@
+{
+  "providers": {
+    "openai-codex": {
+      "modelOverrides": {
+        "gpt-5.6-luna": {
+          "contextWindow": 1050000
+        },
+        "gpt-5.6-sol": {
+          "contextWindow": 1050000
+        },
+        "gpt-5.6-terra": {
+          "contextWindow": 1050000
+        }
+      }
+    }
+  }
+}

--- a/dot_pi/agent/settings.json.tmpl
+++ b/dot_pi/agent/settings.json.tmpl
@@ -5,7 +5,7 @@
   "defaultModel": "gemini-3.7-flash",
   "defaultProvider": "google",
 {{- else }}
-  "defaultModel": "gpt-5.6-luna",
+  "defaultModel": "gpt-5.6-sol",
   "defaultProvider": "openai-codex",
 {{- end }}
   "defaultThinkingLevel": "high",
@@ -23,5 +23,10 @@
     "npm:pi-input-history"
   ],
   "quietStartup": true,
+  "subagents": {
+    "defaultModel": "openai-codex/gpt-5.6-luna:high",
+    "defaultProvider": "openai-codex",
+    "defaultThinking": "high"
+  },
   "theme": "dark"
 }

--- a/dot_pi/agent/settings.json.tmpl
+++ b/dot_pi/agent/settings.json.tmpl
@@ -26,7 +26,29 @@
   "subagents": {
     "defaultModel": "openai-codex/gpt-5.6-luna:high",
     "defaultProvider": "openai-codex",
-    "defaultThinking": "high"
+    "defaultThinking": "high",
+    "agentOverrides": {
+      "worker": {
+        "model": "openai-codex/gpt-5.6-luna:high",
+        "fallbackModels": ["google/gemini-3.8-flash:high"]
+      },
+      "delegate": {
+        "model": "openai-codex/gpt-5.6-luna:high",
+        "fallbackModels": ["google/gemini-3.8-flash:high"]
+      },
+      "reviewer": {
+        "model": "openai-codex/gpt-5.6-luna:high",
+        "fallbackModels": ["google/gemini-3.8-flash:high"]
+      },
+      "oracle": {
+        "model": "openai-codex/gpt-5.6-sol:high",
+        "fallbackModels": ["google/gemini-3.8-flash:high"]
+      },
+      "scout": {
+        "model": "openai-codex/gpt-5.6-luna:high",
+        "fallbackModels": ["google/gemini-3.8-flash:high"]
+      }
+    }
   },
   "theme": "dark"
 }

--- a/run_after_system-deploy.sh.tmpl
+++ b/run_after_system-deploy.sh.tmpl
@@ -6,6 +6,7 @@ CHEZMOI_SOURCE="{{ .chezmoi.sourceDir }}"
 SYSTEM_DIR="$CHEZMOI_SOURCE/system"
 SERVER_DIR="$SYSTEM_DIR/hetzner"
 ARCH_DIR="$SYSTEM_DIR/arch"
+nginx_changed=0
 
 [ ! -d "$SYSTEM_DIR" ] && exit 0
 
@@ -23,8 +24,15 @@ install_file() {
 
   if ! cmp -s "$src" "$dest" 2>/dev/null; then
     echo "System file changed: $dest"
-    sudo install -Dm"$mode" -o "$owner" -g "$group" "$src" "$dest" || \
+    if sudo install -Dm"$mode" -o "$owner" -g "$group" "$src" "$dest"; then
+      case "$dest" in
+        /etc/nginx/*)
+          nginx_changed=1
+          ;;
+      esac
+    else
       echo "WARN: needs sudo or service account for $dest"
+    fi
   else
     # Keep permissions and ownership correct even when file contents are unchanged.
     sudo chmod "$mode" "$dest" 2>/dev/null || true
@@ -90,4 +98,12 @@ for stale in /etc/nginx/conf.d/solux.conf /www/data/index.html /www/data/index.c
   [ -e "$stale" ] && echo "WARN: stale server file remains on non-hetzner host: $stale"
 done
 {{ end -}}
+
+if [ "$nginx_changed" -eq 1 ]; then
+  if sudo nginx -t; then
+    sudo systemctl reload nginx || echo "WARN: Nginx reload failed"
+  else
+    echo "WARN: Nginx configuration test failed; reload skipped"
+  fi
+fi
 {{ end -}}

--- a/system/hetzner/etc/nginx/conf.d/jellyfin.conf
+++ b/system/hetzner/etc/nginx/conf.d/jellyfin.conf
@@ -8,6 +8,15 @@ location /jellyfin {
 # The / at the end is significant.
 # https://www.acunetix.com/blog/articles/a-fresh-look-on-reverse-proxy-related-attacks/
 location /jellyfin/ {
+    # LG webOS clients fail with error -27 when X-Frame-Options is SAMEORIGIN.
+    more_clear_headers X-Frame-Options;
+    add_header X-Frame-Options "" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer-when-downgrade" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Content-Security-Policy "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob: wss: ws: https://unpkg.com https://www.googletagmanager.com https://www.google-analytics.com; img-src 'self' data: blob: https:; connect-src 'self' blob: https: wss: ws:;" always;
+
     # Proxy main Jellyfin traffic
 
     root /usr/share/jellyfin-web/;

--- a/system/hetzner/etc/nginx/conf.d/job-applier.conf
+++ b/system/hetzner/etc/nginx/conf.d/job-applier.conf
@@ -57,7 +57,7 @@ location ^~ /job-applier/ {
     # Rewrite root-relative asset and API paths in HTML, JSON, and JS
     # so that the entire Job Applier interface operates seamlessly under /job-applier/
     proxy_set_header Accept-Encoding "";
-    sub_filter_types text/html application/json application/javascript;
+    sub_filter_types application/json application/javascript text/javascript;
     sub_filter_once off;
 
     # API endpoints and file storage paths

--- a/system/hetzner/etc/nginx/conf.d/lavish.conf
+++ b/system/hetzner/etc/nginx/conf.d/lavish.conf
@@ -36,11 +36,7 @@ location = /lavish/chrome-client.js {
     sub_filter '/api/' '/lavish/api/';
     sub_filter '/events/' '/lavish/events/';
     sub_filter '/artifact/' '/lavish/artifact/';
-    sub_filter '/artifact-failures' '/lavish/artifact-failures';
-    sub_filter '/artifact-loads/' '/lavish/artifact-loads/';
-    sub_filter '/feedback-files' '/lavish/feedback-files';
     sub_filter '/whiteboard-frame' '/lavish/whiteboard-frame';
-    sub_filter '/whiteboard/' '/lavish/whiteboard/';
 }
 
 location ^~ /lavish/artifact/ {


### PR DESCRIPTION
## Summary
- add GPT/Codex fallback behavior and persist Pi operating rules
- track model-specific context windows in the Pi status footer
- opt GPT-5.6 Sol, Terra, and Luna into the 1.05M context ceiling
- track the Minikube user service
- reload nginx automatically after system config deployment
- fix Jellyfin webOS headers and Hetzner proxy asset handling
- ignore managed `.worktrees/` directories

## Validation
- `pi --list-models` reports 1.1M for GPT-5.6 Sol, Terra, and Luna
- verified the status footer switches from 128k to 1.1M when changing models
- `git diff --check`
