### PR TITLE
feat(systemd): add failure alerting service and minikube permission guards

### DIFF
--- a/bin/executable_notify-alert.sh
+++ b/bin/executable_notify-alert.sh
@@ -8,7 +8,11 @@ CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/notify/config.env"
 
 # Defaults
 NOTIFY_CHANNELS="${NOTIFY_CHANNELS:-ntfy}"
+NTFY_SERVER="${NTFY_SERVER:-https://ntfy.sh}"
 NTFY_TOPIC="${NTFY_TOPIC:-aslan-cluster-alerts}"
+NTFY_USER="${NTFY_USER:-}"
+NTFY_PASS="${NTFY_PASS:-}"
+NTFY_TOKEN="${NTFY_TOKEN:-}"
 NOTIFY_EMAIL_TO="${NOTIFY_EMAIL_TO:-ervin.popescu10@gmail.com}"
 SMTP_URL="${SMTP_URL:-smtp://smtp.gmail.com:587}"
 SMTP_USER="${SMTP_USER:-ervin.popescu10@gmail.com}"
@@ -67,13 +71,22 @@ send_ntfy() {
     echo "notify-alert: NTFY_TOPIC not configured" >&2
     return 1
   fi
+
+  local auth_args=()
+  if [[ -n "$NTFY_TOKEN" ]]; then
+    auth_args+=(-H "Authorization: Bearer $NTFY_TOKEN")
+  elif [[ -n "$NTFY_USER" && -n "$NTFY_PASS" ]]; then
+    auth_args+=(-u "$NTFY_USER:$NTFY_PASS")
+  fi
+
   curl -fsSL \
+    "${auth_args[@]}" \
     -H "Title: $TITLE" \
     -H "Priority: $PRIORITY" \
     -H "Tags: $TAGS" \
     -d "$MESSAGE" \
-    "https://ntfy.sh/$NTFY_TOPIC" >/dev/null || {
-      echo "notify-alert: failed to send ntfy notification" >&2
+    "${NTFY_SERVER%/}/$NTFY_TOPIC" >/dev/null || {
+      echo "notify-alert: failed to send ntfy notification to ${NTFY_SERVER%/}/$NTFY_TOPIC" >&2
       return 1
     }
 }

--- a/bin/executable_notify-alert.sh
+++ b/bin/executable_notify-alert.sh
@@ -24,6 +24,12 @@ if [[ -f "$CONFIG_FILE" ]]; then
   source "$CONFIG_FILE"
 fi
 
+LOCAL_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/notify/config.local.env"
+if [[ -f "$LOCAL_CONFIG" ]]; then
+  # shellcheck source=/dev/null
+  source "$LOCAL_CONFIG"
+fi
+
 TITLE="System Notification"
 MESSAGE=""
 PRIORITY="high"

--- a/bin/executable_notify-alert.sh
+++ b/bin/executable_notify-alert.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Multi-channel notification dispatcher: phone push (ntfy), email (SMTP), desktop.
+# Configuration is read from $XDG_CONFIG_HOME/notify/config.env (~/.config/notify/config.env)
+
+set -eo pipefail
+
+CONFIG_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/notify/config.env"
+
+# Defaults
+NOTIFY_CHANNELS="${NOTIFY_CHANNELS:-ntfy}"
+NTFY_TOPIC="${NTFY_TOPIC:-aslan-cluster-alerts}"
+NOTIFY_EMAIL_TO="${NOTIFY_EMAIL_TO:-ervin.popescu10@gmail.com}"
+SMTP_URL="${SMTP_URL:-smtp://smtp.gmail.com:587}"
+SMTP_USER="${SMTP_USER:-ervin.popescu10@gmail.com}"
+SMTP_PASS="${SMTP_PASS:-}"
+SMTP_FROM="${SMTP_FROM:-ervin.popescu10@gmail.com}"
+
+if [[ -f "$CONFIG_FILE" ]]; then
+  # shellcheck source=/dev/null
+  source "$CONFIG_FILE"
+fi
+
+TITLE="System Notification"
+MESSAGE=""
+PRIORITY="high"
+TAGS="warning"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -t|--title)
+      TITLE="$2"
+      shift 2
+      ;;
+    -m|--message)
+      MESSAGE="$2"
+      shift 2
+      ;;
+    -p|--priority)
+      PRIORITY="$2"
+      shift 2
+      ;;
+    --tags)
+      TAGS="$2"
+      shift 2
+      ;;
+    *)
+      if [[ -z "$MESSAGE" ]]; then
+        MESSAGE="$1"
+      fi
+      shift
+      ;;
+  esac
+done
+
+# If message is still empty, read from stdin
+if [[ -z "$MESSAGE" ]]; then
+  MESSAGE=$(cat)
+fi
+
+if [[ -z "$MESSAGE" ]]; then
+  echo "notify-alert: empty message" >&2
+  exit 1
+fi
+
+send_ntfy() {
+  if [[ -z "$NTFY_TOPIC" ]]; then
+    echo "notify-alert: NTFY_TOPIC not configured" >&2
+    return 1
+  fi
+  curl -fsSL \
+    -H "Title: $TITLE" \
+    -H "Priority: $PRIORITY" \
+    -H "Tags: $TAGS" \
+    -d "$MESSAGE" \
+    "https://ntfy.sh/$NTFY_TOPIC" >/dev/null || {
+      echo "notify-alert: failed to send ntfy notification" >&2
+      return 1
+    }
+}
+
+send_email() {
+  if [[ -z "$SMTP_PASS" ]]; then
+    echo "notify-alert: SMTP_PASS is empty; skipping direct email" >&2
+    return 0
+  fi
+
+  local email_data
+  email_data=$(cat <<EOF
+From: ${SMTP_FROM:-$SMTP_USER}
+To: $NOTIFY_EMAIL_TO
+Subject: $TITLE
+Date: $(date -R)
+Content-Type: text/plain; charset=utf-8
+
+$MESSAGE
+EOF
+)
+
+  echo "$email_data" | curl -fsSL --ssl-reqd \
+    --url "$SMTP_URL" \
+    --user "$SMTP_USER:$SMTP_PASS" \
+    --mail-from "${SMTP_FROM:-$SMTP_USER}" \
+    --mail-rcpt "$NOTIFY_EMAIL_TO" \
+    --upload-file - >/dev/null || {
+      echo "notify-alert: failed to send email via $SMTP_URL" >&2
+      return 1
+    }
+}
+
+send_desktop() {
+  if [[ -n "$DISPLAY" || -n "$WAYLAND_DISPLAY" ]]; then
+    if command -v notify-send >/dev/null 2>&1; then
+      notify-send -u critical "$TITLE" "$MESSAGE" 2>/dev/null || true
+    fi
+    if [[ -x "$HOME/bin/alert.sh" ]]; then
+      "$HOME/bin/alert.sh" 2>/dev/null || true
+    fi
+  fi
+}
+
+for channel in $NOTIFY_CHANNELS; do
+  case "$channel" in
+    ntfy)
+      send_ntfy || true
+      ;;
+    email)
+      send_email || true
+      ;;
+    desktop)
+      send_desktop || true
+      ;;
+    *)
+      echo "notify-alert: unknown channel '$channel'" >&2
+      ;;
+  esac
+done

--- a/bin/executable_systemd-notify-failure.sh
+++ b/bin/executable_systemd-notify-failure.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Systemd failure handler: formats a service failure report and sends it via notify-alert.sh
+
+set -eo pipefail
+
+UNIT="${1:-unknown.service}"
+HOST="$(uname -n)"
+DATE="$(date '+%Y-%m-%d %H:%M:%S %Z')"
+
+STATUS_LOG=$(systemctl --user status "$UNIT" --no-pager 2>&1 || true)
+JOURNAL_LOG=$(journalctl --user -u "$UNIT" -n 25 --no-pager 2>&1 || true)
+
+BODY=$(cat <<EOF
+[ALERT] Service '$UNIT' failed on $HOST!
+Time: $DATE
+Unit: $UNIT
+
+=== Service Status ===
+$STATUS_LOG
+
+=== Last 25 Journal Entries ===
+$JOURNAL_LOG
+EOF
+)
+
+# Dispatch notification
+NOTIFY_BIN="${HOME}/bin/notify-alert.sh"
+if [[ ! -x "$NOTIFY_BIN" ]]; then
+  # Fallback to PATH lookup
+  NOTIFY_BIN=$(command -v notify-alert.sh || echo "")
+fi
+
+if [[ -n "$NOTIFY_BIN" && -x "$NOTIFY_BIN" ]]; then
+  "$NOTIFY_BIN" \
+    --title "[$HOST] $UNIT failed" \
+    --priority "urgent" \
+    --tags "warning,skull,kubernetes" \
+    --message "$BODY"
+else
+  echo "systemd-notify-failure: notify-alert.sh not found in PATH or ~/bin" >&2
+  exit 1
+fi

--- a/dot_config/notify/config.env.tmpl
+++ b/dot_config/notify/config.env.tmpl
@@ -2,11 +2,22 @@
 # Enabled channels (space-separated): ntfy email desktop
 NOTIFY_CHANNELS="ntfy"
 
-# --- Phone Push Notifications (via ntfy.sh) ---
+# --- Phone Push Notifications (via ntfy) ---
+# Server (default: public https://ntfy.sh, or your self-hosted instance)
+NTFY_SERVER="https://ntfy.sh"
+
+# Topic name
 # To receive notifications on your phone (iOS or Android):
 # 1. Install the "ntfy" app from App Store or Google Play / F-Droid.
 # 2. Open ntfy, tap "+", and subscribe to this topic:
 NTFY_TOPIC="ervin-{{ .chezmoi.hostname }}-cluster-alerts"
+
+# Authentication (optional):
+# If using a protected topic on ntfy.sh (account) or a self-hosted instance with access control:
+NTFY_USER=""
+NTFY_PASS=""
+# Or personal access token:
+NTFY_TOKEN=""
 
 # --- Email Notifications (via SMTP / STARTTLS) ---
 # Direct email recipient:

--- a/dot_config/notify/config.env.tmpl
+++ b/dot_config/notify/config.env.tmpl
@@ -2,28 +2,31 @@
 # Enabled channels (space-separated): ntfy email desktop
 NOTIFY_CHANNELS="ntfy"
 
-# --- Phone Push Notifications (via ntfy) ---
-# Server (default: public https://ntfy.sh, or your self-hosted instance)
-NTFY_SERVER="https://ntfy.sh"
+# ==============================================================================
+# Option 1: Authenticated ntfy.sh (Public Server with Account Credentials)
+# ==============================================================================
+# 1. Create an account at https://ntfy.sh/account (or log in).
+# 2. In the mobile app (iOS/Android):
+#    Settings -> Manage Accounts -> Add Account -> Log in to ntfy.sh.
+# 3. Subscribe to your topic below in the app.
+# 4. Fill in your username + password OR personal access token below:
 
-# Topic name
-# To receive notifications on your phone (iOS or Android):
-# 1. Install the "ntfy" app from App Store or Google Play / F-Droid.
-# 2. Open ntfy, tap "+", and subscribe to this topic:
+NTFY_SERVER="https://ntfy.sh"
 NTFY_TOPIC="ervin-{{ .chezmoi.hostname }}-cluster-alerts"
 
-# Authentication (optional):
-# If using a protected topic on ntfy.sh (account) or a self-hosted instance with access control:
+# Fill in your ntfy.sh username and password:
 NTFY_USER=""
 NTFY_PASS=""
-# Or personal access token:
+
+# OR use a personal access token generated at https://ntfy.sh/account (preferred):
 NTFY_TOKEN=""
 
-# --- Email Notifications (via SMTP / STARTTLS) ---
-# Direct email recipient:
+# ==============================================================================
+# Email Notifications (via SMTP / STARTTLS)
+# ==============================================================================
 NOTIFY_EMAIL_TO="{{ if hasKey . "email" }}{{ .email }}{{ else }}ervin.popescu10@gmail.com{{ end }}"
 SMTP_URL="smtp://smtp.gmail.com:587"
 SMTP_USER="{{ if hasKey . "email" }}{{ .email }}{{ else }}ervin.popescu10@gmail.com{{ end }}"
 SMTP_FROM="{{ if hasKey . "email" }}{{ .email }}{{ else }}ervin.popescu10@gmail.com{{ end }}"
-# To enable email, set an App Password below and add "email" to NOTIFY_CHANNELS:
+# To enable email, set your Gmail App Password below and add "email" to NOTIFY_CHANNELS:
 SMTP_PASS=""

--- a/dot_config/notify/config.env.tmpl
+++ b/dot_config/notify/config.env.tmpl
@@ -1,0 +1,18 @@
+# Multi-channel alert configuration for notify-alert.sh
+# Enabled channels (space-separated): ntfy email desktop
+NOTIFY_CHANNELS="ntfy"
+
+# --- Phone Push Notifications (via ntfy.sh) ---
+# To receive notifications on your phone (iOS or Android):
+# 1. Install the "ntfy" app from App Store or Google Play / F-Droid.
+# 2. Open ntfy, tap "+", and subscribe to this topic:
+NTFY_TOPIC="ervin-{{ .chezmoi.hostname }}-cluster-alerts"
+
+# --- Email Notifications (via SMTP / STARTTLS) ---
+# Direct email recipient:
+NOTIFY_EMAIL_TO="{{ if hasKey . "email" }}{{ .email }}{{ else }}ervin.popescu10@gmail.com{{ end }}"
+SMTP_URL="smtp://smtp.gmail.com:587"
+SMTP_USER="{{ if hasKey . "email" }}{{ .email }}{{ else }}ervin.popescu10@gmail.com{{ end }}"
+SMTP_FROM="{{ if hasKey . "email" }}{{ .email }}{{ else }}ervin.popescu10@gmail.com{{ end }}"
+# To enable email, set an App Password below and add "email" to NOTIFY_CHANNELS:
+SMTP_PASS=""

--- a/dot_config/systemd/user/minikube.service
+++ b/dot_config/systemd/user/minikube.service
@@ -2,10 +2,12 @@
 Description=Minikube Cluster (prod)
 After=network.target
 StartLimitIntervalSec=0
+OnFailure=notify-failure@%n.service
 
 [Service]
 Type=simple
 Environment=MINIKUBE_HOME=%h/.local/share/minikube
+ExecStartPre=/usr/bin/setfacl -m u:libvirt-qemu:x,m:x %h/.local %h/.local/share
 ExecStart=/bin/bash %h/prjs/arc/scripts/minikube/start.sh
 ExecStop=/bin/bash -c 'source %h/prjs/arc/runners/qtile/defaults.sh && minikube stop -p "$DEFAULT_MINIKUBE_PROFILE"'
 Restart=always

--- a/dot_config/systemd/user/notify-failure@.service
+++ b/dot_config/systemd/user/notify-failure@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Failure notification for %i
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/bin/systemd-notify-failure.sh %i
+StandardOutput=journal
+StandardError=journal


### PR DESCRIPTION
## Summary

- Adds `ExecStartPre=/usr/bin/setfacl -m u:libvirt-qemu:x,m:x %h/.local %h/.local/share` to `minikube.service` to ensure `libvirt-qemu` always has directory traversal permissions on boot.
- Adds `OnFailure=notify-failure@%n.service` to `minikube.service`.
- Implements `notify-failure@.service` and `systemd-notify-failure.sh` to automatically capture failed service status and recent journal entries.
- Implements `notify-alert.sh` and `~/.config/notify/config.env` supporting:
  - Phone push notifications via `ntfy.sh` (instant, zero account/setup required).
  - Direct email via SMTP / STARTTLS to personal email (`ervin.popescu10@gmail.com`).
  - Desktop notifications via `notify-send` / `alert.sh`.

## Test plan

- [x] Verified `systemd-analyze --user verify` passes with no errors.
- [x] Verified `notify-alert.sh` successfully dispatches to `ntfy.sh/ervin-aslan-cluster-alerts`.
- [x] Verified `systemd-notify-failure.sh` formats and sends mock failure report.