### PR TITLE
feat(system): add dry-run mode and unified diff preview to system deployment

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -7,6 +7,7 @@ tmp
 configs
 docs/**
 system/**
+tests/**
 markdown/**
 secrets.age
 pkgs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Secrets are age-encrypted. Place the age key at `~/.config/chezmoi/key.txt` befo
 
 - `dot_config/` — XDG config home (`$HOME/.config`), chezmoi source layout
 - `bin/` — user scripts for `$HOME/bin` (prefixed `executable_`)
-- `system/` — system-level configs (`/etc/`, `/usr/`), deployed via `run_after_system-deploy.sh.tmpl` (subtrees for `arch/` and `hetzner/` are conditionally applied; preview with `chezmoi-dry-apply` or `system-deploy.sh --dry-run`)
+- `system/` — system-level configs (`/etc/`, `/usr/`), deployed via `run_after_system-deploy.sh.tmpl` (subtrees for `arch/` and `hetzner/` are conditionally applied; preview with `chezmoi-dry-apply` or `system-deploy.sh --dry-run`; note that `chezmoi apply --dry-run` alone skips hooks; wrappers auto-detect active worktrees)
 - `pkgs` — full list of installed packages
 - `.chezmoi.toml.tmpl` — chezmoi config template (machine detection, secrets, age settings)
 - `.chezmoiignore` — machine-conditional file exclusion

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Secrets are age-encrypted. Place the age key at `~/.config/chezmoi/key.txt` befo
 
 - `dot_config/` — XDG config home (`$HOME/.config`), chezmoi source layout
 - `bin/` — user scripts for `$HOME/bin` (prefixed `executable_`)
-- `system/` — system-level configs (`/etc/`, `/usr/`), deployed via `run_after_system-deploy.sh.tmpl` (subtrees for `arch/` and `hetzner/` are conditionally applied)
+- `system/` — system-level configs (`/etc/`, `/usr/`), deployed via `run_after_system-deploy.sh.tmpl` (subtrees for `arch/` and `hetzner/` are conditionally applied; preview with `chezmoi-dry-apply` or `system-deploy.sh --dry-run`)
 - `pkgs` — full list of installed packages
 - `.chezmoi.toml.tmpl` — chezmoi config template (machine detection, secrets, age settings)
 - `.chezmoiignore` — machine-conditional file exclusion

--- a/README.md
+++ b/README.md
@@ -51,17 +51,31 @@ chezmoi-dry-apply
 This single command previews both normal chezmoi user dotfile changes
 (`chezmoi apply --dry-run --verbose`) and system configuration changes.
 
+> **Warning:** Running `chezmoi apply --dry-run` or `chezmoi diff` alone
+> **skips post-apply lifecycle hooks** (`run_after_system-deploy.sh.tmpl`).
+> Running `chezmoi apply --dry-run` will therefore never preview system files
+> under `/etc` or `/usr`. Always use `chezmoi-dry-apply` to safely inspect both
+> user dotfiles and system changes together.
+
 To preview system configuration changes alone, run:
 
 ```bash
 system-deploy.sh --dry-run   # or: system-deploy.sh -n
 ```
 
-This displays unified diffs and file mode/owner changes for all pending system files.
-Because `chezmoi diff` and `chezmoi apply --dry-run` intentionally skip post-apply
-scripts, `chezmoi-dry-apply` and `system-deploy.sh` provide safe dry-run inspection
-interfaces. Setting `DRY_RUN=1` in the environment also triggers dry-run mode for
-system deployment.
+Key dry-run safety features:
+
+- **Worktree Source Detection:** When invoked from inside a git feature worktree,
+  both `chezmoi-dry-apply` and `system-deploy.sh` automatically detect and use that
+  worktree's source templates instead of falling back to the main configured chezmoi
+  source path.
+- **Fail-Closed Protection:** If `--dry-run` is requested but the target template
+  lacks explicit dry-run capability headers (`SYSTEM_DEPLOY_CAPABILITIES`), execution
+  aborts immediately with an error to prevent accidental live mutation.
+- **Guarded Destructive Cleanup:** Decommissioned configurations and service removals
+  are reported as `[dry-run] would remove ...` without deleting any files, and service
+  reloads (such as Nginx) are skipped. Setting `DRY_RUN=1` in the environment also
+  activates dry-run mode.
 
 The former `archnet-cfg` repository remains useful for destructive Hetzner
 installation, package bootstrap, and service-data migration. It must not also

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ cp /path/to/key.txt ~/.config/chezmoi/key.txt
 chezmoi init --source /path/to/this/repo
 
 # 4. Preview, then apply
-chezmoi diff
-chezmoi apply
+chezmoi-dry-apply            # preview both user dotfiles and system changes
+chezmoi apply                # apply dotfiles and deploy system files
 ```
 
 System files under `system/` (e.g. `/etc/zsh/zshenv`) are deployed automatically
@@ -40,6 +40,28 @@ via a post-apply script with `sudo`. The `system/arch/` subtree is applied only 
 Arch Linux systems, and the `system/hetzner/` subtree is applied only when the
 machine profile is `aslan`/`hetzner`; it contains the server's Nginx,
 monitoring, security, and service overrides.
+
+To preview pending changes safely without mutating `/etc`, modifying files, or
+reloading services, run:
+
+```bash
+chezmoi-dry-apply
+```
+
+This single command previews both normal chezmoi user dotfile changes
+(`chezmoi apply --dry-run --verbose`) and system configuration changes.
+
+To preview system configuration changes alone, run:
+
+```bash
+system-deploy.sh --dry-run   # or: system-deploy.sh -n
+```
+
+This displays unified diffs and file mode/owner changes for all pending system files.
+Because `chezmoi diff` and `chezmoi apply --dry-run` intentionally skip post-apply
+scripts, `chezmoi-dry-apply` and `system-deploy.sh` provide safe dry-run inspection
+interfaces. Setting `DRY_RUN=1` in the environment also triggers dry-run mode for
+system deployment.
 
 The former `archnet-cfg` repository remains useful for destructive Hetzner
 installation, package bootstrap, and service-data migration. It must not also

--- a/bin/executable_chezmoi-dry-apply
+++ b/bin/executable_chezmoi-dry-apply
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -euo pipefail
+
+# Preview both chezmoi user dotfile changes and system configuration deployment
+# in dry-run mode without modifying any files or restarting services.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source_dir=""
+has_source=0
+has_force=0
+has_interactive=0
+apply_args=()
+
+print_help() {
+  local name
+  name="$(basename "$0")"
+  if [ "$name" = "executable_chezmoi-dry-apply" ]; then
+    name="chezmoi-dry-apply"
+  fi
+  cat << EOF
+Usage: $name [OPTIONS] [TARGET...]
+
+Preview both chezmoi user dotfile changes and system configuration deployment
+in dry-run mode without modifying any files or restarting services.
+
+Executes:
+  1. chezmoi apply --dry-run --verbose [OPTIONS] [TARGET...]
+  2. system-deploy.sh --dry-run
+
+Options:
+  -h, --help           Show this help message and exit
+  -n, --dry-run        Accepted for compatibility (dry-run is always active)
+  -S, --source PATH    Use specified chezmoi source directory
+
+All other options and target paths are forwarded to chezmoi apply.
+Source options (-S, --source) are shared with system deployment inspection.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h | --help)
+      print_help
+      exit 0
+      ;;
+    -n | --dry-run)
+      shift
+      ;;
+    -S | --source)
+      if [ $# -lt 2 ]; then
+        echo "Error: $1 requires a directory path" >&2
+        exit 1
+      fi
+      source_dir="$2"
+      has_source=1
+      apply_args+=("$1" "$2")
+      shift 2
+      ;;
+    --source=*)
+      source_dir="${1#*=}"
+      has_source=1
+      apply_args+=("$1")
+      shift
+      ;;
+    --force)
+      has_force=1
+      apply_args+=("$1")
+      shift
+      ;;
+    --interactive | --less-interactive)
+      has_interactive=1
+      apply_args+=("$1")
+      shift
+      ;;
+    *)
+      apply_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [ -n "$source_dir" ]; then
+  source_dir="$(cd "$source_dir" 2>/dev/null && pwd || echo "$source_dir")"
+fi
+
+if [ -z "$source_dir" ]; then
+  if [ -n "${SYSTEM_SOURCE_DIR:-}" ] && [ -f "$SYSTEM_SOURCE_DIR/run_after_system-deploy.sh.tmpl" ]; then
+    source_dir="$SYSTEM_SOURCE_DIR"
+  elif [ -n "${CHEZMOI_SOURCE_DIR:-}" ] && [ -f "$CHEZMOI_SOURCE_DIR/run_after_system-deploy.sh.tmpl" ]; then
+    source_dir="$CHEZMOI_SOURCE_DIR"
+  elif [ -f "$SCRIPT_DIR/../run_after_system-deploy.sh.tmpl" ]; then
+    source_dir="$(cd "$SCRIPT_DIR/.." && pwd)"
+  else
+    source_dir="$(chezmoi source-path 2>/dev/null || true)"
+    if [ -z "$source_dir" ] || [ ! -f "$source_dir/run_after_system-deploy.sh.tmpl" ]; then
+      if [ -f "$HOME/.local/share/chezmoi/run_after_system-deploy.sh.tmpl" ]; then
+        source_dir="$HOME/.local/share/chezmoi"
+      fi
+    fi
+  fi
+fi
+
+if [ -n "$source_dir" ]; then
+  export SYSTEM_SOURCE_DIR="$source_dir"
+fi
+
+# Build chezmoi apply invocation
+chezmoi_cmd=(chezmoi)
+if [ "$has_source" -eq 0 ] && [ -n "$source_dir" ]; then
+  chezmoi_cmd+=(-S "$source_dir")
+fi
+chezmoi_cmd+=(apply --dry-run --verbose)
+
+# In non-interactive environments without a controlling terminal, default to
+# --force to prevent chezmoi from aborting on modified targets when prompting.
+if ! (: < /dev/tty) 2>/dev/null && [ "$has_interactive" -eq 0 ] && [ "$has_force" -eq 0 ]; then
+  chezmoi_cmd+=(--force)
+fi
+
+if [ ${#apply_args[@]} -gt 0 ]; then
+  chezmoi_cmd+=("${apply_args[@]}")
+fi
+
+"${chezmoi_cmd[@]}"
+
+# Locate system-deploy script
+deploy_cmd=""
+if [ -n "${SYSTEM_DEPLOY_BIN:-}" ] && [ -x "$SYSTEM_DEPLOY_BIN" ]; then
+  deploy_cmd="$SYSTEM_DEPLOY_BIN"
+elif [ -x "$SCRIPT_DIR/system-deploy.sh" ]; then
+  deploy_cmd="$SCRIPT_DIR/system-deploy.sh"
+elif [ -x "$SCRIPT_DIR/executable_system-deploy.sh" ]; then
+  deploy_cmd="$SCRIPT_DIR/executable_system-deploy.sh"
+elif command -v system-deploy.sh >/dev/null 2>&1; then
+  deploy_cmd="$(command -v system-deploy.sh)"
+elif [ -n "$source_dir" ] && [ -x "$source_dir/bin/executable_system-deploy.sh" ]; then
+  deploy_cmd="$source_dir/bin/executable_system-deploy.sh"
+elif [ -n "$source_dir" ] && [ -x "$source_dir/bin/system-deploy.sh" ]; then
+  deploy_cmd="$source_dir/bin/system-deploy.sh"
+fi
+
+if [ -n "$deploy_cmd" ]; then
+  "$deploy_cmd" --dry-run
+elif [ -n "$source_dir" ] && [ -f "$source_dir/run_after_system-deploy.sh.tmpl" ]; then
+  rendered="$(chezmoi -S "$source_dir" execute-template '{{ includeTemplate "run_after_system-deploy.sh.tmpl" . }}')"
+  if [ -n "$(echo "$rendered" | tr -d '[:space:]')" ]; then
+    bash -s -- --dry-run <<< "$rendered"
+  fi
+else
+  echo "WARN: could not locate system-deploy script to preview system files" >&2
+fi

--- a/bin/executable_chezmoi-dry-apply
+++ b/bin/executable_chezmoi-dry-apply
@@ -88,12 +88,21 @@ if [ -z "$source_dir" ]; then
     source_dir="$SYSTEM_SOURCE_DIR"
   elif [ -n "${CHEZMOI_SOURCE_DIR:-}" ] && [ -f "$CHEZMOI_SOURCE_DIR/run_after_system-deploy.sh.tmpl" ]; then
     source_dir="$CHEZMOI_SOURCE_DIR"
-  elif [ -f "$SCRIPT_DIR/../run_after_system-deploy.sh.tmpl" ]; then
-    source_dir="$(cd "$SCRIPT_DIR/.." && pwd)"
   else
-    source_dir="$(chezmoi source-path 2>/dev/null || true)"
-    if [ -z "$source_dir" ] || [ ! -f "$source_dir/run_after_system-deploy.sh.tmpl" ]; then
-      if [ -f "$HOME/.local/share/chezmoi/run_after_system-deploy.sh.tmpl" ]; then
+    git_worktree="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    if [ -n "$git_worktree" ] && [ -f "$git_worktree/run_after_system-deploy.sh.tmpl" ]; then
+      source_dir="$git_worktree"
+    elif [ -f "$SCRIPT_DIR/../run_after_system-deploy.sh.tmpl" ]; then
+      source_dir="$(cd "$SCRIPT_DIR/.." && pwd)"
+    elif [ -n "${SYSTEM_SOURCE_DIR:-}" ] && [ -d "$SYSTEM_SOURCE_DIR" ]; then
+      source_dir="$SYSTEM_SOURCE_DIR"
+    elif [ -n "${CHEZMOI_SOURCE_DIR:-}" ] && [ -d "$CHEZMOI_SOURCE_DIR" ]; then
+      source_dir="$CHEZMOI_SOURCE_DIR"
+    else
+      configured="$(chezmoi source-path 2>/dev/null || true)"
+      if [ -n "$configured" ] && [ -f "$configured/run_after_system-deploy.sh.tmpl" ]; then
+        source_dir="$configured"
+      elif [ -f "$HOME/.local/share/chezmoi/run_after_system-deploy.sh.tmpl" ]; then
         source_dir="$HOME/.local/share/chezmoi"
       fi
     fi
@@ -127,24 +136,29 @@ fi
 deploy_cmd=""
 if [ -n "${SYSTEM_DEPLOY_BIN:-}" ] && [ -x "$SYSTEM_DEPLOY_BIN" ]; then
   deploy_cmd="$SYSTEM_DEPLOY_BIN"
+elif [ -n "$source_dir" ] && [ -x "$source_dir/bin/executable_system-deploy.sh" ]; then
+  deploy_cmd="$source_dir/bin/executable_system-deploy.sh"
+elif [ -n "$source_dir" ] && [ -x "$source_dir/bin/system-deploy.sh" ]; then
+  deploy_cmd="$source_dir/bin/system-deploy.sh"
 elif [ -x "$SCRIPT_DIR/system-deploy.sh" ]; then
   deploy_cmd="$SCRIPT_DIR/system-deploy.sh"
 elif [ -x "$SCRIPT_DIR/executable_system-deploy.sh" ]; then
   deploy_cmd="$SCRIPT_DIR/executable_system-deploy.sh"
 elif command -v system-deploy.sh >/dev/null 2>&1; then
   deploy_cmd="$(command -v system-deploy.sh)"
-elif [ -n "$source_dir" ] && [ -x "$source_dir/bin/executable_system-deploy.sh" ]; then
-  deploy_cmd="$source_dir/bin/executable_system-deploy.sh"
-elif [ -n "$source_dir" ] && [ -x "$source_dir/bin/system-deploy.sh" ]; then
-  deploy_cmd="$source_dir/bin/system-deploy.sh"
 fi
 
 if [ -n "$deploy_cmd" ]; then
-  "$deploy_cmd" --dry-run
+  "$deploy_cmd" --dry-run -S "$source_dir"
 elif [ -n "$source_dir" ] && [ -f "$source_dir/run_after_system-deploy.sh.tmpl" ]; then
   rendered="$(chezmoi -S "$source_dir" execute-template '{{ includeTemplate "run_after_system-deploy.sh.tmpl" . }}')"
   if [ -n "$(echo "$rendered" | tr -d '[:space:]')" ]; then
-    bash -s -- --dry-run <<< "$rendered"
+    if ! grep -q '^# SYSTEM_DEPLOY_CAPABILITIES:.*dry-run' <<< "$rendered"; then
+      echo "Error: system deployment template does not support dry-run protocol." >&2
+      echo "Aborting to prevent unintentional live system modifications." >&2
+      exit 1
+    fi
+    bash -s -- --dry-run -S "$source_dir" <<< "$rendered"
   fi
 else
   echo "WARN: could not locate system-deploy script to preview system files" >&2

--- a/bin/executable_system-deploy.sh
+++ b/bin/executable_system-deploy.sh
@@ -6,18 +6,77 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR=""
+cli_source=0
+dry_run=0
+if [ "${DRY_RUN:-0}" = "1" ] || [ "${SYSTEM_DEPLOY_DRY_RUN:-0}" = "1" ] || [ "${CHEZMOI_DRY_RUN:-0}" = "1" ]; then
+  dry_run=1
+fi
+passthrough_args=()
 
-if [ -n "${SYSTEM_SOURCE_DIR:-}" ] && [ -f "$SYSTEM_SOURCE_DIR/run_after_system-deploy.sh.tmpl" ]; then
-  SOURCE_DIR="$SYSTEM_SOURCE_DIR"
-elif [ -f "$SCRIPT_DIR/../run_after_system-deploy.sh.tmpl" ]; then
-  SOURCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-elif [ -n "${SYSTEM_SOURCE_DIR:-}" ] && [ -d "$SYSTEM_SOURCE_DIR" ]; then
-  SOURCE_DIR="$SYSTEM_SOURCE_DIR"
-else
-  SOURCE_DIR="$(chezmoi source-path 2>/dev/null || true)"
-  if [ -z "$SOURCE_DIR" ] || [ ! -f "$SOURCE_DIR/run_after_system-deploy.sh.tmpl" ]; then
-    if [ -f "$HOME/.local/share/chezmoi/run_after_system-deploy.sh.tmpl" ]; then
-      SOURCE_DIR="$HOME/.local/share/chezmoi"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n | --dry-run)
+      dry_run=1
+      passthrough_args+=("$1")
+      shift
+      ;;
+    -S | --source)
+      if [ $# -lt 2 ]; then
+        echo "Error: $1 requires a directory path" >&2
+        exit 1
+      fi
+      SOURCE_DIR="$2"
+      cli_source=1
+      passthrough_args+=("$1" "$2")
+      shift 2
+      ;;
+    --source=*)
+      SOURCE_DIR="${1#*=}"
+      cli_source=1
+      passthrough_args+=("$1")
+      shift
+      ;;
+    -h | --help)
+      echo "Usage: system-deploy.sh [OPTIONS]"
+      echo ""
+      echo "Deploy system-level configurations to /etc, /usr, etc."
+      echo ""
+      echo "Options:"
+      echo "  -n, --dry-run        Preview system changes and unified diffs without modifying files"
+      echo "  -S, --source PATH    Use specified chezmoi source directory"
+      echo "  -h, --help           Show this help message"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: system-deploy.sh [-n|--dry-run] [-S|--source PATH] [-h|--help]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -n "$SOURCE_DIR" ]; then
+  SOURCE_DIR="$(cd "$SOURCE_DIR" 2>/dev/null && pwd || echo "$SOURCE_DIR")"
+fi
+
+if [ -z "$SOURCE_DIR" ]; then
+  if [ -n "${SYSTEM_SOURCE_DIR:-}" ] && [ -f "$SYSTEM_SOURCE_DIR/run_after_system-deploy.sh.tmpl" ]; then
+    SOURCE_DIR="$SYSTEM_SOURCE_DIR"
+  else
+    git_worktree="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+    if [ -n "$git_worktree" ] && [ -f "$git_worktree/run_after_system-deploy.sh.tmpl" ]; then
+      SOURCE_DIR="$git_worktree"
+    elif [ -f "$SCRIPT_DIR/../run_after_system-deploy.sh.tmpl" ]; then
+      SOURCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+    elif [ -n "${SYSTEM_SOURCE_DIR:-}" ] && [ -d "$SYSTEM_SOURCE_DIR" ]; then
+      SOURCE_DIR="$SYSTEM_SOURCE_DIR"
+    else
+      configured="$(chezmoi source-path 2>/dev/null || true)"
+      if [ -n "$configured" ] && [ -f "$configured/run_after_system-deploy.sh.tmpl" ]; then
+        SOURCE_DIR="$configured"
+      elif [ -f "$HOME/.local/share/chezmoi/run_after_system-deploy.sh.tmpl" ]; then
+        SOURCE_DIR="$HOME/.local/share/chezmoi"
+      fi
     fi
   fi
 fi
@@ -27,6 +86,12 @@ if [ -z "$SOURCE_DIR" ] || [ ! -f "$SOURCE_DIR/run_after_system-deploy.sh.tmpl" 
   exit 1
 fi
 
+if [ "$cli_source" -eq 1 ]; then
+  export SYSTEM_SOURCE_DIR="$SOURCE_DIR"
+elif [ -z "${SYSTEM_SOURCE_DIR:-}" ]; then
+  export SYSTEM_SOURCE_DIR="$SOURCE_DIR"
+fi
+
 rendered="$(chezmoi -S "$SOURCE_DIR" execute-template '{{ includeTemplate "run_after_system-deploy.sh.tmpl" . }}')"
 
 if [ -z "$(echo "$rendered" | tr -d '[:space:]')" ]; then
@@ -34,4 +99,12 @@ if [ -z "$(echo "$rendered" | tr -d '[:space:]')" ]; then
   exit 0
 fi
 
-bash -s -- "$@" <<< "$rendered"
+if [ "$dry_run" -eq 1 ]; then
+  if ! grep -q '^# SYSTEM_DEPLOY_CAPABILITIES:.*dry-run' <<< "$rendered"; then
+    echo "Error: system deployment template does not support dry-run protocol." >&2
+    echo "Aborting to prevent unintentional live system modifications." >&2
+    exit 1
+  fi
+fi
+
+bash -s -- "${passthrough_args[@]}" <<< "$rendered"

--- a/bin/executable_system-deploy.sh
+++ b/bin/executable_system-deploy.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+# System configuration deployment helper.
+# Supports -n / --dry-run to preview unified diffs without modifying files.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR=""
+
+if [ -n "${SYSTEM_SOURCE_DIR:-}" ] && [ -f "$SYSTEM_SOURCE_DIR/run_after_system-deploy.sh.tmpl" ]; then
+  SOURCE_DIR="$SYSTEM_SOURCE_DIR"
+elif [ -f "$SCRIPT_DIR/../run_after_system-deploy.sh.tmpl" ]; then
+  SOURCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+elif [ -n "${SYSTEM_SOURCE_DIR:-}" ] && [ -d "$SYSTEM_SOURCE_DIR" ]; then
+  SOURCE_DIR="$SYSTEM_SOURCE_DIR"
+else
+  SOURCE_DIR="$(chezmoi source-path 2>/dev/null || true)"
+  if [ -z "$SOURCE_DIR" ] || [ ! -f "$SOURCE_DIR/run_after_system-deploy.sh.tmpl" ]; then
+    if [ -f "$HOME/.local/share/chezmoi/run_after_system-deploy.sh.tmpl" ]; then
+      SOURCE_DIR="$HOME/.local/share/chezmoi"
+    fi
+  fi
+fi
+
+if [ -z "$SOURCE_DIR" ] || [ ! -f "$SOURCE_DIR/run_after_system-deploy.sh.tmpl" ]; then
+  echo "Error: could not locate chezmoi source directory or run_after_system-deploy.sh.tmpl" >&2
+  exit 1
+fi
+
+rendered="$(chezmoi -S "$SOURCE_DIR" execute-template '{{ includeTemplate "run_after_system-deploy.sh.tmpl" . }}')"
+
+if [ -z "$(echo "$rendered" | tr -d '[:space:]')" ]; then
+  echo "System deployment is not configured for this machine profile."
+  exit 0
+fi
+
+bash -s -- "$@" <<< "$rendered"

--- a/markdown/features.md
+++ b/markdown/features.md
@@ -52,6 +52,7 @@ Two configs: `qtile/` (X11) and `qtile-wl/` (Wayland). Both share the same archi
 
 ~70 user scripts covering:
 
+- Dry-run apply & deployment (`chezmoi-dry-apply` for combined user & system diffs, `system-deploy.sh` with `--dry-run` / `-n`)
 - Wallpaper management (`wallpaper.sh`, `rofi-wallpaper`, `run_wall.sh`)
 - Theme switching (`change_theme.py`)
 - System info (`filesizes.sh`, `all_disk_usage.sh`, `bt-bat.py`, `location.py`)

--- a/markdown/features.md
+++ b/markdown/features.md
@@ -52,7 +52,7 @@ Two configs: `qtile/` (X11) and `qtile-wl/` (Wayland). Both share the same archi
 
 ~70 user scripts covering:
 
-- Dry-run apply & deployment (`chezmoi-dry-apply` for combined user & system diffs, `system-deploy.sh` with `--dry-run` / `-n`)
+- Dry-run apply & deployment (`chezmoi-dry-apply` for combined user & system diffs, `system-deploy.sh` with `--dry-run` / `-n`; fails closed on unsupported templates, auto-detects worktree source)
 - Wallpaper management (`wallpaper.sh`, `rofi-wallpaper`, `run_wall.sh`)
 - Theme switching (`change_theme.py`)
 - System info (`filesizes.sh`, `all_disk_usage.sh`, `bt-bat.py`, `location.py`)

--- a/markdown/profiles.md
+++ b/markdown/profiles.md
@@ -15,7 +15,7 @@ stored in `.machine`; it is separate from the hostname in some cases.
 
 `is_arch` is derived from the host operating system, not hardcoded to a
 profile. The `hetzner` profile enables the Aslan-only `system/hetzner/` tree,
-including Nginx, monitoring, security, systemd, and Transmission configuration.
+including Nginx, monitoring, security, and systemd configuration.
 The `system/arch/` tree (`pacman.conf`, `reflector.conf`) is applied only when
 `is_arch` is true.
 
@@ -59,5 +59,4 @@ do not infer server behavior from `is_linux`.
 - Wayland Qtile files are included only for `lenovo`.
 - GUI-heavy desktop configuration is excluded for `macbook` and `hetzner`.
 - Cloudtop receives the HiDPI/X11 settings and Apigee-related Neovim LSP setup.
-- Aslan receives the `system/hetzner/` runtime configuration and the private
-  Transmission settings template.
+- Aslan receives the `system/hetzner/` runtime configuration.

--- a/markdown/tree.md
+++ b/markdown/tree.md
@@ -47,7 +47,7 @@ dots/                              # chezmoi source directory
 │       ├── plugins/               # Zsh plugins
 │       └── files/                 # Misc zsh files
 │
-├── system/                        # System-level configs, deployed via run_after_ script
+├── system/                        # System-level configs, deployed via run_after_ script (preview: chezmoi-dry-apply or system-deploy.sh -n)
 │   ├── arch/                      # Arch-only system configuration
 │   │   └── etc/                   # pacman.conf, reflector.conf
 │   ├── etc/

--- a/run_after_system-deploy.sh.tmpl
+++ b/run_after_system-deploy.sh.tmpl
@@ -1,5 +1,6 @@
 {{ if .is_linux -}}
 #!/bin/bash
+# SYSTEM_DEPLOY_CAPABILITIES: dry-run,unified-diff
 set -euo pipefail
 
 CHEZMOI_SOURCE="${SYSTEM_SOURCE_DIR:-{{ .chezmoi.sourceDir }}}"
@@ -27,19 +28,38 @@ while [ $# -gt 0 ]; do
       dry_run=1
       shift
       ;;
+    -S|--source)
+      if [ $# -lt 2 ]; then
+        echo "Error: $1 requires a directory path" >&2
+        exit 1
+      fi
+      CHEZMOI_SOURCE="$2"
+      SYSTEM_DIR="$CHEZMOI_SOURCE/system"
+      SERVER_DIR="$SYSTEM_DIR/hetzner"
+      ARCH_DIR="$SYSTEM_DIR/arch"
+      shift 2
+      ;;
+    --source=*)
+      CHEZMOI_SOURCE="${1#*=}"
+      SYSTEM_DIR="$CHEZMOI_SOURCE/system"
+      SERVER_DIR="$SYSTEM_DIR/hetzner"
+      ARCH_DIR="$SYSTEM_DIR/arch"
+      shift
+      ;;
     -h|--help)
       echo "Usage: $script_name [OPTIONS]"
       echo ""
       echo "Deploy system-level configurations to /etc, /usr, etc."
       echo ""
       echo "Options:"
-      echo "  -n, --dry-run    Preview system changes and unified diffs without modifying files"
-      echo "  -h, --help       Show this help message"
+      echo "  -n, --dry-run        Preview system changes and unified diffs without modifying files"
+      echo "  -S, --source PATH    Use specified chezmoi source directory"
+      echo "  -h, --help           Show this help message"
       exit 0
       ;;
     *)
       echo "Unknown option: $1" >&2
-      echo "Usage: $script_name [-n|--dry-run] [-h|--help]" >&2
+      echo "Usage: $script_name [-n|--dry-run] [-S|--source PATH] [-h|--help]" >&2
       exit 1
       ;;
   esac
@@ -73,7 +93,7 @@ content_matches() {
 
 get_metadata() {
   local target="$1"
-  if [ -n "$DEST_ROOT" ] && [ -w "${DEST_ROOT:-/}" ]; then
+  if [ -n "$DEST_ROOT" ]; then
     stat -c "%a %U %G" "$target" 2>/dev/null || echo ""
   else
     stat -c "%a %U %G" "$target" 2>/dev/null || sudo -n stat -c "%a %U %G" "$target" 2>/dev/null || echo ""
@@ -186,7 +206,7 @@ install_file() {
       echo "System file changed: $display_path"
       local -a install_cmd=(install -Dm"$mode" -o "$owner" -g "$group" "$src" "$dest")
       local install_ok=0
-      if [ -n "$DEST_ROOT" ] && [ -w "${DEST_ROOT:-/}" ]; then
+      if [ -n "$DEST_ROOT" ]; then
         if [ "$(id -u)" -ne 0 ]; then
           install_cmd=(install -Dm"$mode" "$src" "$dest")
         fi
@@ -210,7 +230,7 @@ install_file() {
       fi
     elif [ "$meta_differs" -eq 1 ]; then
       # Keep permissions and ownership correct even when file contents are unchanged.
-      if [ -n "$DEST_ROOT" ] && [ -w "${DEST_ROOT:-/}" ]; then
+      if [ -n "$DEST_ROOT" ]; then
         chmod "$mode" "$dest" 2>/dev/null || true
         if [ "$(id -u)" -eq 0 ]; then
           chown "$owner:$group" "$dest" 2>/dev/null || true
@@ -283,13 +303,29 @@ if [ -d "$SERVER_DIR" ]; then
   report_stale "$SERVER_DIR/etc/fail2ban/jail.d" /etc/fail2ban/jail.d
   report_stale "$SERVER_DIR/etc/ssh/sshd_config.d" /etc/ssh/sshd_config.d
 
-  # Clean up decommissioned transmission configurations
+  # Clean up decommissioned transmission configurations only when absent from source
   for stale in /etc/nginx/conf.d/transmission.conf /etc/systemd/system/transmission.service.d /etc/systemd/system/transmission-daemon.service.d; do
-    if [ -e "$stale" ]; then
-      echo "Removing decommissioned transmission config: $stale"
-      sudo rm -rf "$stale"
-      if [[ "$stale" == /etc/nginx/* ]]; then
-        nginx_changed=1
+    if [ -e "$SERVER_DIR$stale" ]; then
+      continue
+    fi
+    target_stale="$DEST_ROOT$stale"
+    if target_exists "$target_stale"; then
+      if [ "$dry_run" -eq 1 ]; then
+        echo "[dry-run] would remove decommissioned transmission config: $stale"
+        changed_files=$((changed_files + 1))
+        if [[ "$stale" == /etc/nginx/* ]]; then
+          nginx_changed=1
+        fi
+      else
+        echo "Removing decommissioned transmission config: $stale"
+        if [ -n "$DEST_ROOT" ]; then
+          rm -rf "$target_stale" || echo "WARN: failed to remove $target_stale"
+        else
+          sudo rm -rf "$target_stale"
+        fi
+        if [[ "$stale" == /etc/nginx/* ]]; then
+          nginx_changed=1
+        fi
       fi
     fi
   done

--- a/run_after_system-deploy.sh.tmpl
+++ b/run_after_system-deploy.sh.tmpl
@@ -2,18 +2,110 @@
 #!/bin/bash
 set -euo pipefail
 
-CHEZMOI_SOURCE="{{ .chezmoi.sourceDir }}"
+CHEZMOI_SOURCE="${SYSTEM_SOURCE_DIR:-{{ .chezmoi.sourceDir }}}"
 SYSTEM_DIR="$CHEZMOI_SOURCE/system"
 SERVER_DIR="$SYSTEM_DIR/hetzner"
 ARCH_DIR="$SYSTEM_DIR/arch"
+DEST_ROOT="${SYSTEM_TARGET_DIR:-}"
+
 nginx_changed=0
+changed_files=0
+
+script_name="$(basename "$0")"
+if [ "$script_name" = "bash" ] || [ "$script_name" = "-s" ] || [ "$script_name" = "sh" ]; then
+  script_name="system-deploy.sh"
+fi
+
+dry_run=0
+if [ "${DRY_RUN:-0}" = "1" ] || [ "${SYSTEM_DEPLOY_DRY_RUN:-0}" = "1" ] || [ "${CHEZMOI_DRY_RUN:-0}" = "1" ]; then
+  dry_run=1
+fi
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -n|--dry-run)
+      dry_run=1
+      shift
+      ;;
+    -h|--help)
+      echo "Usage: $script_name [OPTIONS]"
+      echo ""
+      echo "Deploy system-level configurations to /etc, /usr, etc."
+      echo ""
+      echo "Options:"
+      echo "  -n, --dry-run    Preview system changes and unified diffs without modifying files"
+      echo "  -h, --help       Show this help message"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      echo "Usage: $script_name [-n|--dry-run] [-h|--help]" >&2
+      exit 1
+      ;;
+  esac
+done
 
 [ ! -d "$SYSTEM_DIR" ] && exit 0
 
-install_file() {
-  local src="$1" dest="$2" mode=644 owner=root group=root
+target_exists() {
+  local target="$1"
+  if [ -e "$target" ] || [ -L "$target" ]; then
+    return 0
+  fi
+  if [ -z "$DEST_ROOT" ] && { sudo -n test -e "$target" 2>/dev/null || sudo -n test -L "$target" 2>/dev/null; }; then
+    return 0
+  fi
+  return 1
+}
 
-  case "$dest" in
+content_matches() {
+  local src="$1" dest="$2"
+  if cmp -s "$src" "$dest" 2>/dev/null; then
+    return 0
+  fi
+  if [ -z "$DEST_ROOT" ] && [ ! -r "$dest" ]; then
+    if sudo -n cmp -s "$src" "$dest" 2>/dev/null; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+get_metadata() {
+  local target="$1"
+  if [ -n "$DEST_ROOT" ] && [ -w "${DEST_ROOT:-/}" ]; then
+    stat -c "%a %U %G" "$target" 2>/dev/null || echo ""
+  else
+    stat -c "%a %U %G" "$target" 2>/dev/null || sudo -n stat -c "%a %U %G" "$target" 2>/dev/null || echo ""
+  fi
+}
+
+print_diff() {
+  local src="$1" dest="$2" display_path="$3" is_new="$4"
+  local -a diff_cmd=(diff -u)
+  if diff --color=auto /dev/null /dev/null 2>/dev/null; then
+    diff_cmd+=(--color=auto)
+  fi
+
+  if [ "$is_new" -eq 1 ]; then
+    "${diff_cmd[@]}" --label /dev/null --label "b$display_path" /dev/null "$src" || true
+  else
+    if [ -r "$dest" ]; then
+      "${diff_cmd[@]}" --label "a$display_path" --label "b$display_path" "$dest" "$src" || true
+    elif [ -z "$DEST_ROOT" ] && sudo -n test -r "$dest" 2>/dev/null; then
+      sudo -n "${diff_cmd[@]}" --label "a$display_path" --label "b$display_path" "$dest" "$src" || true
+    else
+      echo "WARN: cannot read $display_path without elevated permissions; diff unavailable"
+    fi
+  fi
+}
+
+install_file() {
+  local src="$1" rel_dest="$2" mode=644 owner=root group=root
+  local dest="$DEST_ROOT$rel_dest"
+  local display_path="$rel_dest"
+
+  case "$display_path" in
     /etc/grafana.ini)
       mode=640
       if getent group grafana >/dev/null 2>&1; then
@@ -22,21 +114,112 @@ install_file() {
       ;;
   esac
 
-  if ! cmp -s "$src" "$dest" 2>/dev/null; then
-    echo "System file changed: $dest"
-    if sudo install -Dm"$mode" -o "$owner" -g "$group" "$src" "$dest"; then
-      case "$dest" in
+  local is_new=0
+  if ! target_exists "$dest"; then
+    is_new=1
+  fi
+
+  local content_differs=0
+  if [ "$is_new" -eq 1 ] || ! content_matches "$src" "$dest"; then
+    content_differs=1
+  fi
+
+  local meta_differs=0
+  local cur_mode="" cur_owner="" cur_group=""
+  if [ "$is_new" -eq 0 ]; then
+    local meta
+    meta="$(get_metadata "$dest")"
+    if [ -n "$meta" ]; then
+      read -r cur_mode cur_owner cur_group <<< "$meta"
+      if [[ "$cur_mode" =~ ^[0-7]+$ ]] && [ "$((8#$cur_mode))" -ne "$((8#$mode))" ]; then
+        meta_differs=1
+      fi
+      if [ -z "$DEST_ROOT" ]; then
+        if [ "$cur_owner" != "$owner" ] || [ "$cur_group" != "$group" ]; then
+          meta_differs=1
+        fi
+      fi
+    fi
+  fi
+
+  if [ "$dry_run" -eq 1 ]; then
+    if [ "$is_new" -eq 1 ]; then
+      echo "diff --git a$display_path b$display_path"
+      echo "new file mode 100$mode ($owner:$group)"
+      print_diff "$src" "$dest" "$display_path" 1
+      changed_files=$((changed_files + 1))
+      case "$display_path" in
         /etc/nginx/*)
           nginx_changed=1
           ;;
       esac
-    else
-      echo "WARN: needs sudo or service account for $dest"
+    elif [ "$content_differs" -eq 1 ]; then
+      echo "diff --git a$display_path b$display_path"
+      if [ "$meta_differs" -eq 1 ]; then
+        if [[ "$cur_mode" =~ ^[0-7]+$ ]] && [ "$((8#$cur_mode))" -ne "$((8#$mode))" ]; then
+          echo "mode: $cur_mode -> $mode"
+        fi
+        if [ -z "$DEST_ROOT" ] && { [ "$cur_owner" != "$owner" ] || [ "$cur_group" != "$group" ]; }; then
+          echo "owner: $cur_owner:$cur_group -> $owner:$group"
+        fi
+      fi
+      print_diff "$src" "$dest" "$display_path" 0
+      changed_files=$((changed_files + 1))
+      case "$display_path" in
+        /etc/nginx/*)
+          nginx_changed=1
+          ;;
+      esac
+    elif [ "$meta_differs" -eq 1 ]; then
+      echo "diff --git a$display_path b$display_path"
+      if [[ "$cur_mode" =~ ^[0-7]+$ ]] && [ "$((8#$cur_mode))" -ne "$((8#$mode))" ]; then
+        echo "mode: $cur_mode -> $mode"
+      fi
+      if [ -z "$DEST_ROOT" ] && { [ "$cur_owner" != "$owner" ] || [ "$cur_group" != "$group" ]; }; then
+        echo "owner: $cur_owner:$cur_group -> $owner:$group"
+      fi
+      echo "(contents unchanged)"
+      changed_files=$((changed_files + 1))
     fi
   else
-    # Keep permissions and ownership correct even when file contents are unchanged.
-    sudo chmod "$mode" "$dest" 2>/dev/null || true
-    sudo chown "$owner:$group" "$dest" 2>/dev/null || true
+    if [ "$content_differs" -eq 1 ]; then
+      echo "System file changed: $display_path"
+      local -a install_cmd=(install -Dm"$mode" -o "$owner" -g "$group" "$src" "$dest")
+      local install_ok=0
+      if [ -n "$DEST_ROOT" ] && [ -w "${DEST_ROOT:-/}" ]; then
+        if [ "$(id -u)" -ne 0 ]; then
+          install_cmd=(install -Dm"$mode" "$src" "$dest")
+        fi
+        if "${install_cmd[@]}"; then
+          install_ok=1
+        fi
+      else
+        if sudo "${install_cmd[@]}"; then
+          install_ok=1
+        fi
+      fi
+
+      if [ "$install_ok" -eq 1 ]; then
+        case "$display_path" in
+          /etc/nginx/*)
+            nginx_changed=1
+            ;;
+        esac
+      else
+        echo "WARN: needs sudo or service account for $display_path"
+      fi
+    elif [ "$meta_differs" -eq 1 ]; then
+      # Keep permissions and ownership correct even when file contents are unchanged.
+      if [ -n "$DEST_ROOT" ] && [ -w "${DEST_ROOT:-/}" ]; then
+        chmod "$mode" "$dest" 2>/dev/null || true
+        if [ "$(id -u)" -eq 0 ]; then
+          chown "$owner:$group" "$dest" 2>/dev/null || true
+        fi
+      else
+        sudo chmod "$mode" "$dest" 2>/dev/null || true
+        sudo chown "$owner:$group" "$dest" 2>/dev/null || true
+      fi
+    fi
   fi
 }
 
@@ -73,17 +256,26 @@ if [ -d "$SERVER_DIR" ]; then
   # may have been installed by the distribution or another service.
   report_stale() {
     local source_dir="$1" target_dir="$2"
-    [ -d "$target_dir" ] || return 0
+    local full_target="$DEST_ROOT$target_dir"
+    [ -d "$full_target" ] || return 0
     while IFS= read -r -d '' dest; do
-      local rel="${dest#"$target_dir/"}"
+      local rel="${dest#"$full_target/"}"
       # This is an Arch-provided baseline, not a repository-managed file.
       if [ "$target_dir" = "/etc/ssh/sshd_config.d" ] && [ "$rel" = "99-archlinux.conf" ]; then
         continue
       fi
       if [ ! -f "$source_dir/$rel" ]; then
-        echo "WARN: stale unmanaged server file remains: $dest"
+        echo "WARN: stale unmanaged server file remains: ${dest#"$DEST_ROOT"}"
       fi
-    done < <(sudo find "$target_dir" -type f -print0 2>/dev/null)
+    done < <(
+      if [ -n "$DEST_ROOT" ]; then
+        find "$full_target" -type f -print0 2>/dev/null
+      elif [ "$dry_run" -eq 1 ]; then
+        sudo -n find "$full_target" -type f -print0 2>/dev/null || find "$full_target" -type f -print0 2>/dev/null || true
+      else
+        sudo find "$full_target" -type f -print0 2>/dev/null
+      fi
+    )
   }
 
   report_stale "$SERVER_DIR/etc/nginx/conf.d" /etc/nginx/conf.d
@@ -106,15 +298,30 @@ fi
 # These paths were previously in the common tree. Report them rather than
 # deleting them automatically if an older apply left them on a workstation.
 for stale in /etc/nginx/conf.d/solux.conf /www/data/index.html /www/data/index.css; do
-  [ -e "$stale" ] && echo "WARN: stale server file remains on non-hetzner host: $stale"
+  [ -e "$DEST_ROOT$stale" ] && echo "WARN: stale server file remains on non-hetzner host: $stale"
 done
 {{ end -}}
 
 if [ "$nginx_changed" -eq 1 ]; then
-  if sudo nginx -t; then
-    sudo systemctl reload nginx || echo "WARN: Nginx reload failed"
+  if [ "$dry_run" -eq 1 ]; then
+    echo "[dry-run] Nginx configuration changed; service reload skipped"
   else
-    echo "WARN: Nginx configuration test failed; reload skipped"
+    if [ -n "$DEST_ROOT" ]; then
+      echo "Nginx configuration changed (custom target root; reload skipped)"
+    elif sudo nginx -t; then
+      sudo systemctl reload nginx || echo "WARN: Nginx reload failed"
+    else
+      echo "WARN: Nginx configuration test failed; reload skipped"
+    fi
+  fi
+fi
+
+if [ "$dry_run" -eq 1 ]; then
+  if [ "$changed_files" -eq 0 ]; then
+    echo "No system file changes detected."
+  else
+    echo ""
+    echo "[dry-run] $changed_files system file(s) would be changed. No system changes applied."
   fi
 fi
 {{ end -}}

--- a/tests/test_chezmoi_dry_apply.sh
+++ b/tests/test_chezmoi_dry_apply.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+set -euo pipefail
+
+# Test suite for chezmoi-dry-apply helper
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DRY_APPLY_BIN="$REPO_ROOT/bin/executable_chezmoi-dry-apply"
+
+passes=0
+failures=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $label"
+    passes=$((passes + 1))
+  else
+    echo "  FAIL: $label"
+    echo "    Expected: '$expected'"
+    echo "    Actual:   '$actual'"
+    failures=$((failures + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $label"
+    passes=$((passes + 1))
+  else
+    echo "  FAIL: $label (did not find '$needle' in output)"
+    echo "    Output was: $haystack"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "Running chezmoi-dry-apply tests..."
+
+# Test 1: --help displays usage
+echo "Test 1: --help displays usage"
+help_out="$("$DRY_APPLY_BIN" --help)"
+assert_contains "help contains usage" "Usage: chezmoi-dry-apply [OPTIONS]" "$help_out"
+assert_contains "help mentions chezmoi apply dry-run" "chezmoi apply --dry-run --verbose" "$help_out"
+assert_contains "help mentions system-deploy dry-run" "system-deploy.sh --dry-run" "$help_out"
+
+# Test 2: Error on missing argument to -S
+echo "Test 2: Missing argument to -S fails"
+if "$DRY_APPLY_BIN" -S >/dev/null 2>&1; then
+  echo "  FAIL: -S without path should return non-zero"
+  failures=$((failures + 1))
+else
+  echo "  PASS: -S without path returns non-zero"
+  passes=$((passes + 1))
+fi
+
+# Setup isolated test environment
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+ISOLATED_SOURCE="$TEST_DIR/source"
+ISOLATED_DEST="$TEST_DIR/dest"
+ISOLATED_SYS_TARGET="$TEST_DIR/sys_target"
+
+mkdir -p "$ISOLATED_SOURCE" "$ISOLATED_DEST" "$ISOLATED_SYS_TARGET/etc/nginx/conf.d"
+
+# Configure minimal chezmoi source with both a user dotfile and system deploy template
+cat << 'EOF' > "$ISOLATED_SOURCE/.chezmoiignore"
+system/**
+tests/**
+EOF
+
+# User dotfile managed by chezmoi
+mkdir -p "$ISOLATED_SOURCE/dot_config/testapp"
+mkdir -p "$ISOLATED_DEST/.config/testapp"
+echo "original-dotfile" > "$ISOLATED_DEST/.config/testapp/config.txt"
+echo "modified-dotfile" > "$ISOLATED_SOURCE/dot_config/testapp/config.txt"
+
+# System file managed by system/ tree
+mkdir -p "$ISOLATED_SOURCE/system/etc/nginx/conf.d"
+echo "original-sys" > "$ISOLATED_SYS_TARGET/etc/nginx/conf.d/test.conf"
+echo "modified-sys" > "$ISOLATED_SOURCE/system/etc/nginx/conf.d/test.conf"
+
+# Copy system-deploy template into isolated source
+cp "$REPO_ROOT/run_after_system-deploy.sh.tmpl" "$ISOLATED_SOURCE/run_after_system-deploy.sh.tmpl"
+mkdir -p "$ISOLATED_SOURCE/bin"
+cp "$REPO_ROOT/bin/executable_system-deploy.sh" "$ISOLATED_SOURCE/bin/executable_system-deploy.sh"
+chmod +x "$ISOLATED_SOURCE/bin/executable_system-deploy.sh"
+
+# Test 3: chezmoi-dry-apply previews BOTH user dotfiles and system deploy
+echo "Test 3: Previews both user dotfiles and system changes without mutating either"
+out="$(SYSTEM_TARGET_DIR="$ISOLATED_SYS_TARGET" "$DRY_APPLY_BIN" -S "$ISOLATED_SOURCE" -D "$ISOLATED_DEST")"
+
+assert_contains "shows dotfile diff header" "diff --git a/.config/testapp/config.txt b/.config/testapp/config.txt" "$out"
+assert_contains "shows dotfile diff addition" "+modified-dotfile" "$out"
+assert_contains "shows system diff header" "diff --git a/etc/nginx/conf.d/test.conf b/etc/nginx/conf.d/test.conf" "$out"
+assert_contains "shows system diff addition" "+modified-sys" "$out"
+assert_contains "shows system dry-run summary" "[dry-run] 1 system file(s) would be changed. No system changes applied." "$out"
+
+# Verify neither user target nor system target was modified
+dest_content="$(cat "$ISOLATED_DEST/.config/testapp/config.txt")"
+assert_eq "user target not modified" "original-dotfile" "$dest_content"
+
+sys_content="$(cat "$ISOLATED_SYS_TARGET/etc/nginx/conf.d/test.conf")"
+assert_eq "system target not modified" "original-sys" "$sys_content"
+
+# Test 4: When clean, system deploy reports no changes
+echo "Test 4: Clean state reports no changes"
+echo "modified-dotfile" > "$ISOLATED_DEST/.config/testapp/config.txt"
+echo "modified-sys" > "$ISOLATED_SYS_TARGET/etc/nginx/conf.d/test.conf"
+
+clean_out="$(SYSTEM_TARGET_DIR="$ISOLATED_SYS_TARGET" "$DRY_APPLY_BIN" -S "$ISOLATED_SOURCE" -D "$ISOLATED_DEST")"
+assert_contains "reports no system file changes" "No system file changes detected." "$clean_out"
+
+# Test 5: Target argument forwarding
+echo "Test 5: Target arguments restrict dotfile preview"
+echo "unrelated-change" > "$ISOLATED_SOURCE/dot_config/testapp/config.txt"
+mkdir -p "$ISOLATED_SOURCE/dot_config/otherapp" "$ISOLATED_DEST/.config/otherapp"
+echo "other-original" > "$ISOLATED_DEST/.config/otherapp/other.txt"
+echo "other-modified" > "$ISOLATED_SOURCE/dot_config/otherapp/other.txt"
+
+target_out="$(SYSTEM_TARGET_DIR="$ISOLATED_SYS_TARGET" "$DRY_APPLY_BIN" -S "$ISOLATED_SOURCE" -D "$ISOLATED_DEST" "$ISOLATED_DEST/.config/otherapp/other.txt")"
+assert_contains "shows specified target diff" ".config/otherapp/other.txt" "$target_out"
+
+# Test 6: SYSTEM_DEPLOY_BIN override honored
+echo "Test 6: SYSTEM_DEPLOY_BIN override honored"
+MOCK_DEPLOY="$TEST_DIR/mock_deploy.sh"
+cat << 'EOF' > "$MOCK_DEPLOY"
+#!/bin/bash
+echo "MOCK_DEPLOY_CALLED: $*"
+EOF
+chmod +x "$MOCK_DEPLOY"
+
+mock_out="$(SYSTEM_DEPLOY_BIN="$MOCK_DEPLOY" "$DRY_APPLY_BIN" -S "$ISOLATED_SOURCE" -D "$ISOLATED_DEST")"
+assert_contains "mock deploy was called with --dry-run" "MOCK_DEPLOY_CALLED: --dry-run" "$mock_out"
+
+# Test 7: Failure propagation from chezmoi apply
+echo "Test 7: Failure from invalid chezmoi argument returns non-zero"
+if "$DRY_APPLY_BIN" --invalid-argument-xyz >/dev/null 2>&1; then
+  echo "  FAIL: invalid chezmoi argument should return non-zero"
+  failures=$((failures + 1))
+else
+  echo "  PASS: invalid chezmoi argument returns non-zero"
+  passes=$((passes + 1))
+fi
+
+echo ""
+echo "Test results: $passes passed, $failures failed"
+if [ "$failures" -gt 0 ]; then
+  exit 1
+fi

--- a/tests/test_system_deploy.sh
+++ b/tests/test_system_deploy.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+set -euo pipefail
+
+# Test suite for system-deploy dry-run functionality
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEPLOY_BIN="$REPO_ROOT/bin/executable_system-deploy.sh"
+
+passes=0
+failures=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "  PASS: $label"
+    passes=$((passes + 1))
+  else
+    echo "  FAIL: $label"
+    echo "    Expected: '$expected'"
+    echo "    Actual:   '$actual'"
+    failures=$((failures + 1))
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $label"
+    passes=$((passes + 1))
+  else
+    echo "  FAIL: $label (did not find '$needle' in output)"
+    echo "    Output was: $haystack"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "Running system-deploy tests..."
+
+# Test 1: --help option
+echo "Test 1: --help displays usage"
+help_out="$("$DEPLOY_BIN" --help)"
+assert_contains "help contains usage" "Usage: system-deploy.sh [OPTIONS]" "$help_out"
+assert_contains "help contains dry-run flag" "-n, --dry-run" "$help_out"
+
+# Test 2: Invalid option exits non-zero
+echo "Test 2: Invalid option fails"
+if "$DEPLOY_BIN" --invalid-flag >/dev/null 2>&1; then
+  echo "  FAIL: invalid flag should return non-zero"
+  failures=$((failures + 1))
+else
+  echo "  PASS: invalid flag returns non-zero"
+  passes=$((passes + 1))
+fi
+
+# Check if system deployment is supported for this machine profile
+check_rendered="$(chezmoi -S "$REPO_ROOT" execute-template '{{ includeTemplate "run_after_system-deploy.sh.tmpl" . }}' 2>/dev/null || true)"
+if [ -z "$(echo "$check_rendered" | tr -d '[:space:]')" ]; then
+  echo "System deployment is not configured for this machine profile (e.g. non-Linux). Skipping deploy tests."
+  echo ""
+  echo "Test results: $passes passed, $failures failed"
+  exit 0
+fi
+
+# Setup isolated test environment for subsequent tests
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+SOURCE_DIR="$TEST_DIR/source"
+TARGET_DIR="$TEST_DIR/target"
+
+# Common fixtures: placed under system/etc to be portable across all Linux profiles
+mkdir -p "$SOURCE_DIR/system/etc/nginx/conf.d"
+mkdir -p "$TARGET_DIR/etc/nginx/conf.d"
+
+# Test 3: Clean state reports no changes
+echo "Test 3: Identical files report no changes"
+echo "test-clean" > "$SOURCE_DIR/system/etc/nginx/conf.d/clean.conf"
+echo "test-clean" > "$TARGET_DIR/etc/nginx/conf.d/clean.conf"
+
+out="$(SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN" --dry-run)"
+assert_contains "clean reports no changes" "No system file changes detected." "$out"
+
+# Test 4: Modified file reports unified diff and zero mutations
+echo "Test 4: Modified file unified diff and zero mutations"
+echo -e "first line\nsecond line\nthird line" > "$TARGET_DIR/etc/nginx/conf.d/mod.conf"
+echo -e "first line\nmodified line\nthird line" > "$SOURCE_DIR/system/etc/nginx/conf.d/mod.conf"
+
+out="$(SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN" --dry-run)"
+assert_contains "shows diff header" "diff --git a/etc/nginx/conf.d/mod.conf b/etc/nginx/conf.d/mod.conf" "$out"
+assert_contains "shows removed line" "-second line" "$out"
+assert_contains "shows added line" "+modified line" "$out"
+assert_contains "reports nginx reload skipped" "[dry-run] Nginx configuration changed; service reload skipped" "$out"
+assert_contains "reports count of changed files" "[dry-run] 1 system file(s) would be changed. No system changes applied." "$out"
+
+# Verify target was NOT mutated
+target_content="$(cat "$TARGET_DIR/etc/nginx/conf.d/mod.conf")"
+assert_contains "target file preserved unchanged" "second line" "$target_content"
+
+# Test 5: New file reports new file mode and full content diff without creating it
+echo "Test 5: New file shows diff from /dev/null and is not created"
+echo -e "new content line 1\nnew content line 2" > "$SOURCE_DIR/system/etc/nginx/conf.d/new.conf"
+
+out="$(SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN" -n)"
+assert_contains "shows new file header" "diff --git a/etc/nginx/conf.d/new.conf b/etc/nginx/conf.d/new.conf" "$out"
+assert_contains "shows new file mode" "new file mode 100644 (root:root)" "$out"
+assert_contains "shows dev null diff" "--- /dev/null" "$out"
+assert_contains "shows new content in diff" "+new content line 1" "$out"
+
+# Verify target was NOT created
+if [ -f "$TARGET_DIR/etc/nginx/conf.d/new.conf" ]; then
+  echo "  FAIL: new file should not exist in target after dry run"
+  failures=$((failures + 1))
+else
+  echo "  PASS: new file does not exist in target after dry run"
+  passes=$((passes + 1))
+fi
+
+# Clean up new.conf from source for next tests
+rm -f "$SOURCE_DIR/system/etc/nginx/conf.d/new.conf"
+
+# Test 6: Permissions change diff
+echo "Test 6: File mode difference reported without mutating mode"
+echo "perm-test" > "$SOURCE_DIR/system/etc/nginx/conf.d/perm.conf"
+echo "perm-test" > "$TARGET_DIR/etc/nginx/conf.d/perm.conf"
+chmod 600 "$TARGET_DIR/etc/nginx/conf.d/perm.conf"
+
+out="$(SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN" --dry-run)"
+assert_contains "reports mode change" "mode: 600 -> 644" "$out"
+assert_contains "notes content unchanged" "(contents unchanged)" "$out"
+
+target_mode="$(stat -c "%a" "$TARGET_DIR/etc/nginx/conf.d/perm.conf")"
+assert_eq "target mode remains 600" "600" "$target_mode"
+
+# Test 7: DRY_RUN=1 environment variable activates dry-run
+echo "Test 7: DRY_RUN=1 environment variable triggers dry run"
+out="$(DRY_RUN=1 SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN")"
+assert_contains "env var activates dry run" "No system changes applied." "$out"
+
+# Test 8: SYSTEM_DEPLOY_DRY_RUN=1 environment variable activates dry-run
+echo "Test 8: SYSTEM_DEPLOY_DRY_RUN=1 triggers dry run"
+out="$(SYSTEM_DEPLOY_DRY_RUN=1 SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN")"
+assert_contains "env var activates dry run" "No system changes applied." "$out"
+
+# Test 9: Live deploy applies changes when not in dry run
+echo "Test 9: Live deploy writes changes to target"
+out="$(SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN")"
+assert_contains "reports system file changed" "System file changed: /etc/nginx/conf.d/mod.conf" "$out"
+
+target_content_after="$(cat "$TARGET_DIR/etc/nginx/conf.d/mod.conf")"
+assert_contains "target file was updated" "modified line" "$target_content_after"
+
+# Test 10: Stale unmanaged files reported (conditioned appropriately by machine profile)
+if grep -q "report_stale" <<< "$check_rendered"; then
+  echo "Test 10: Stale unmanaged server file warning (server profile)"
+  mkdir -p "$SOURCE_DIR/system/hetzner/etc/nginx/conf.d"
+  echo "stale content" > "$TARGET_DIR/etc/nginx/conf.d/unmanaged.conf"
+  out="$(SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN" --dry-run)"
+  assert_contains "reports stale unmanaged file" "WARN: stale unmanaged server file remains: /etc/nginx/conf.d/unmanaged.conf" "$out"
+  rm -f "$TARGET_DIR/etc/nginx/conf.d/unmanaged.conf"
+else
+  echo "Test 10: Stale workstation server file warning (workstation profile)"
+  mkdir -p "$TARGET_DIR/etc/nginx/conf.d"
+  echo "stale content" > "$TARGET_DIR/etc/nginx/conf.d/solux.conf"
+  out="$(SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN" --dry-run)"
+  assert_contains "reports stale workstation file" "WARN: stale server file remains on non-hetzner host: /etc/nginx/conf.d/solux.conf" "$out"
+  rm -f "$TARGET_DIR/etc/nginx/conf.d/solux.conf"
+fi
+
+# Test 11: bin/executable_system-deploy.sh honors SYSTEM_SOURCE_DIR
+echo "Test 11: executable_system-deploy.sh honors SYSTEM_SOURCE_DIR"
+CUSTOM_SOURCE="$TEST_DIR/custom_source"
+mkdir -p "$CUSTOM_SOURCE"
+cat << 'EOF' > "$CUSTOM_SOURCE/run_after_system-deploy.sh.tmpl"
+{{ if .is_linux -}}
+echo "CUSTOM_SOURCE_DEPLOY_RUN"
+{{ end -}}
+EOF
+custom_out="$(SYSTEM_SOURCE_DIR="$CUSTOM_SOURCE" "$DEPLOY_BIN")"
+assert_contains "custom SYSTEM_SOURCE_DIR honored" "CUSTOM_SOURCE_DEPLOY_RUN" "$custom_out"
+
+# Test 12: Avoid redundant chmod/chown on unchanged files when metadata is already correct
+echo "Test 12: Avoid redundant chmod/chown when metadata is already correct"
+chmod 644 "$TARGET_DIR/etc/nginx/conf.d/clean.conf"
+ctime_before="$(stat -c "%Z" "$TARGET_DIR/etc/nginx/conf.d/clean.conf")"
+sleep 1
+SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN" >/dev/null
+ctime_after="$(stat -c "%Z" "$TARGET_DIR/etc/nginx/conf.d/clean.conf")"
+assert_eq "file ctime preserved when metadata already matches" "$ctime_before" "$ctime_after"
+
+# When metadata differs, live deploy updates permissions
+chmod 600 "$TARGET_DIR/etc/nginx/conf.d/clean.conf"
+SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN" >/dev/null
+mode_after="$(stat -c "%a" "$TARGET_DIR/etc/nginx/conf.d/clean.conf")"
+assert_eq "file mode updated when metadata differed" "644" "$mode_after"
+
+echo ""
+echo "Test results: $passes passed, $failures failed"
+if [ "$failures" -gt 0 ]; then
+  exit 1
+fi

--- a/tests/test_system_deploy.sh
+++ b/tests/test_system_deploy.sh
@@ -35,6 +35,18 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  PASS: $label"
+    passes=$((passes + 1))
+  else
+    echo "  FAIL: $label (unexpectedly found '$needle' in output)"
+    echo "    Output was: $haystack"
+    failures=$((failures + 1))
+  fi
+}
+
 echo "Running system-deploy tests..."
 
 # Test 1: --help option
@@ -64,7 +76,7 @@ fi
 
 # Setup isolated test environment for subsequent tests
 TEST_DIR="$(mktemp -d)"
-trap 'rm -rf "$TEST_DIR"' EXIT
+trap 'chmod -R 777 "$TEST_DIR" 2>/dev/null || true; rm -rf "$TEST_DIR"' EXIT
 
 SOURCE_DIR="$TEST_DIR/source"
 TARGET_DIR="$TEST_DIR/target"
@@ -193,6 +205,211 @@ chmod 600 "$TARGET_DIR/etc/nginx/conf.d/clean.conf"
 SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN" >/dev/null
 mode_after="$(stat -c "%a" "$TARGET_DIR/etc/nginx/conf.d/clean.conf")"
 assert_eq "file mode updated when metadata differed" "644" "$mode_after"
+
+# Test 13: Tracked Transmission source is preserved and not decommissioned
+if grep -q "report_stale" <<< "$check_rendered"; then
+  echo "Test 13: Tracked transmission source is preserved and not treated as decommissioned"
+  TRACKED_SRC="$TEST_DIR/tracked_trans_src"
+  TRACKED_TGT="$TEST_DIR/tracked_trans_tgt"
+  mkdir -p "$TRACKED_SRC/system/hetzner/etc/nginx/conf.d"
+  mkdir -p "$TRACKED_SRC/system/hetzner/etc/systemd/system/transmission.service.d"
+  echo "server { listen 9091; }" > "$TRACKED_SRC/system/hetzner/etc/nginx/conf.d/transmission.conf"
+  echo "[Service]" > "$TRACKED_SRC/system/hetzner/etc/systemd/system/transmission.service.d/override.conf"
+
+  mkdir -p "$TRACKED_TGT/etc/nginx/conf.d"
+  mkdir -p "$TRACKED_TGT/etc/systemd/system/transmission.service.d"
+  echo "old nginx config" > "$TRACKED_TGT/etc/nginx/conf.d/transmission.conf"
+  echo "old service dropin" > "$TRACKED_TGT/etc/systemd/system/transmission.service.d/override.conf"
+
+  # Dry-run: shows diff, does not report decommissioned
+  out_tracked_dry="$(SYSTEM_SOURCE_DIR="$TRACKED_SRC" SYSTEM_TARGET_DIR="$TRACKED_TGT" "$DEPLOY_BIN" --dry-run)"
+  assert_contains "diff shown for tracked transmission config" "diff --git a/etc/nginx/conf.d/transmission.conf b/etc/nginx/conf.d/transmission.conf" "$out_tracked_dry"
+  assert_not_contains "tracked nginx config not previewed as decommissioned" "[dry-run] would remove decommissioned transmission config: /etc/nginx/conf.d/transmission.conf" "$out_tracked_dry"
+  assert_not_contains "tracked dropin not previewed as decommissioned" "[dry-run] would remove decommissioned transmission config: /etc/systemd/system/transmission.service.d" "$out_tracked_dry"
+
+  # Live mode: updates target and does not remove
+  out_tracked_live="$(SYSTEM_SOURCE_DIR="$TRACKED_SRC" SYSTEM_TARGET_DIR="$TRACKED_TGT" "$DEPLOY_BIN")"
+  assert_contains "reports transmission config changed" "System file changed: /etc/nginx/conf.d/transmission.conf" "$out_tracked_live"
+  assert_not_contains "tracked nginx config not removed as decommissioned" "Removing decommissioned transmission config: /etc/nginx/conf.d/transmission.conf" "$out_tracked_live"
+  assert_not_contains "tracked dropin not removed as decommissioned" "Removing decommissioned transmission config: /etc/systemd/system/transmission.service.d" "$out_tracked_live"
+  if [ -f "$TRACKED_TGT/etc/nginx/conf.d/transmission.conf" ] && [ -f "$TRACKED_TGT/etc/systemd/system/transmission.service.d/override.conf" ]; then
+    echo "  PASS: tracked transmission configs exist in target after live deploy"
+    passes=$((passes + 1))
+  else
+    echo "  FAIL: tracked transmission configs missing after live deploy"
+    failures=$((failures + 1))
+  fi
+  tracked_content="$(cat "$TRACKED_TGT/etc/nginx/conf.d/transmission.conf")"
+  assert_contains "target was updated to tracked source content" "server { listen 9091; }" "$tracked_content"
+fi
+
+# Test 14: Genuine decommissioned target is reported in dry run and removed in live mode
+if grep -q "report_stale" <<< "$check_rendered"; then
+  echo "Test 14: Genuine decommissioned target reported in dry-run and removed in live mode"
+  DECOM_SRC="$TEST_DIR/decom_src"
+  DECOM_TGT="$TEST_DIR/decom_tgt"
+  mkdir -p "$DECOM_SRC/system/hetzner" # No transmission configs in source
+  mkdir -p "$DECOM_TGT/etc/nginx/conf.d"
+  mkdir -p "$DECOM_TGT/etc/systemd/system/transmission-daemon.service.d"
+  echo "stale nginx" > "$DECOM_TGT/etc/nginx/conf.d/transmission.conf"
+  echo "stale daemon dropin" > "$DECOM_TGT/etc/systemd/system/transmission-daemon.service.d/override.conf"
+
+  # Dry-run
+  out_decom_dry="$(SYSTEM_SOURCE_DIR="$DECOM_SRC" SYSTEM_TARGET_DIR="$DECOM_TGT" "$DEPLOY_BIN" --dry-run)"
+  assert_contains "previews transmission nginx removal" "[dry-run] would remove decommissioned transmission config: /etc/nginx/conf.d/transmission.conf" "$out_decom_dry"
+  assert_contains "previews transmission daemon dropin removal" "[dry-run] would remove decommissioned transmission config: /etc/systemd/system/transmission-daemon.service.d" "$out_decom_dry"
+  assert_contains "reports nginx reload skipped" "[dry-run] Nginx configuration changed; service reload skipped" "$out_decom_dry"
+
+  # Target files must NOT be deleted in dry-run
+  if [ -f "$DECOM_TGT/etc/nginx/conf.d/transmission.conf" ] && [ -f "$DECOM_TGT/etc/systemd/system/transmission-daemon.service.d/override.conf" ]; then
+    echo "  PASS: transmission configs preserved during dry run"
+    passes=$((passes + 1))
+  else
+    echo "  FAIL: transmission configs were deleted during dry run"
+    failures=$((failures + 1))
+  fi
+
+  # Live mode: files are deleted
+  out_decom_live="$(SYSTEM_SOURCE_DIR="$DECOM_SRC" SYSTEM_TARGET_DIR="$DECOM_TGT" "$DEPLOY_BIN")"
+  assert_contains "reports live removal of nginx config" "Removing decommissioned transmission config: /etc/nginx/conf.d/transmission.conf" "$out_decom_live"
+  assert_contains "reports live removal of daemon dropin" "Removing decommissioned transmission config: /etc/systemd/system/transmission-daemon.service.d" "$out_decom_live"
+  if [ ! -e "$DECOM_TGT/etc/nginx/conf.d/transmission.conf" ] && [ ! -e "$DECOM_TGT/etc/systemd/system/transmission-daemon.service.d" ]; then
+    echo "  PASS: transmission configs removed during live deploy"
+    passes=$((passes + 1))
+  else
+    echo "  FAIL: transmission configs were not removed during live deploy"
+    failures=$((failures + 1))
+  fi
+fi
+
+# Test 15: Non-writable DEST_ROOT cannot cause deletion of host /etc or call sudo
+if grep -q "report_stale" <<< "$check_rendered"; then
+  echo "Test 15: Non-writable DEST_ROOT cannot escape to host /etc or call sudo"
+  RO_TGT="$TEST_DIR/ro_tgt"
+  mkdir -p "$RO_TGT/etc/systemd/system/transmission-daemon.service.d"
+  echo "stale daemon dropin" > "$RO_TGT/etc/systemd/system/transmission-daemon.service.d/override.conf"
+  # Make directory non-writable so rm -rf fails inside target
+  chmod 555 "$RO_TGT/etc/systemd/system"
+
+  SUDO_LOG="$TEST_DIR/sudo_invocations.log"
+  MOCK_BIN_RO="$TEST_DIR/mock_bin_ro"
+  mkdir -p "$MOCK_BIN_RO"
+  cat << EOF > "$MOCK_BIN_RO/sudo"
+#!/bin/bash
+echo "SUDO_CALLED: \$*" >> "$SUDO_LOG"
+exit 1
+EOF
+  chmod +x "$MOCK_BIN_RO/sudo"
+
+  set +e
+  ro_out="$(PATH="$MOCK_BIN_RO:$PATH" SYSTEM_SOURCE_DIR="$DECOM_SRC" SYSTEM_TARGET_DIR="$RO_TGT" "$DEPLOY_BIN" 2>&1)"
+  set -euo pipefail
+
+  chmod 755 "$RO_TGT/etc/systemd/system"
+
+  if [ -f "$SUDO_LOG" ]; then
+    echo "  FAIL: sudo was called during execution with non-writable DEST_ROOT: $(cat "$SUDO_LOG")"
+    failures=$((failures + 1))
+  else
+    echo "  PASS: sudo was never called when DEST_ROOT was non-writable"
+    passes=$((passes + 1))
+  fi
+  assert_not_contains "host /etc never referenced in destructive command" "rm -rf /etc" "$ro_out"
+fi
+
+# Setup mock environment for worktree and protocol tests
+MOCK_BIN="$TEST_DIR/mock_bin"
+mkdir -p "$MOCK_BIN"
+LEGACY_SOURCE="$TEST_DIR/legacy_source"
+mkdir -p "$LEGACY_SOURCE/system/etc/nginx/conf.d"
+cat << 'EOF' > "$LEGACY_SOURCE/run_after_system-deploy.sh.tmpl"
+{{ if .is_linux -}}
+#!/bin/bash
+set -euo pipefail
+echo "LEGACY_EXECUTED"
+{{ end -}}
+EOF
+
+REAL_CHEZMOI="$(command -v chezmoi)"
+cat << EOF > "$MOCK_BIN/chezmoi"
+#!/bin/bash
+if [ "\$1" = "source-path" ]; then
+  echo "$LEGACY_SOURCE"
+  exit 0
+fi
+exec "$REAL_CHEZMOI" "\$@"
+EOF
+chmod +x "$MOCK_BIN/chezmoi"
+
+INSTALLED_BIN="$TEST_DIR/installed_bin"
+mkdir -p "$INSTALLED_BIN"
+cp "$DEPLOY_BIN" "$INSTALLED_BIN/system-deploy.sh"
+chmod +x "$INSTALLED_BIN/system-deploy.sh"
+
+FEATURE_WT="$TEST_DIR/feature_wt"
+mkdir -p "$FEATURE_WT/system/etc/nginx/conf.d"
+git -C "$FEATURE_WT" init -q
+cp "$REPO_ROOT/run_after_system-deploy.sh.tmpl" "$FEATURE_WT/run_after_system-deploy.sh.tmpl"
+echo "feature-wt-content" > "$FEATURE_WT/system/etc/nginx/conf.d/feat-wt.conf"
+
+# Test 16: Installed wrapper called inside a feature worktree resolves that worktree's source
+echo "Test 16: Installed wrapper inside worktree resolves worktree source instead of chezmoi source-path"
+wt_out="$(
+  cd "$FEATURE_WT"
+  PATH="$MOCK_BIN:$PATH" SYSTEM_TARGET_DIR="$TARGET_DIR" "$INSTALLED_BIN/system-deploy.sh" --dry-run
+)"
+assert_contains "worktree source diff shown" "feat-wt.conf" "$wt_out"
+assert_contains "dry-run summary shown" "No system changes applied." "$wt_out"
+assert_not_contains "legacy source template was not executed" "LEGACY_EXECUTED" "$wt_out"
+
+# Test 17: Dry-run fails closed on unsupported legacy template
+echo "Test 17: Dry-run fails closed on unsupported legacy template"
+OUTSIDE_DIR="$TEST_DIR/outside_wt"
+mkdir -p "$OUTSIDE_DIR"
+set +e
+legacy_out="$(
+  cd "$OUTSIDE_DIR"
+  PATH="$MOCK_BIN:$PATH" SYSTEM_TARGET_DIR="$TARGET_DIR" "$INSTALLED_BIN/system-deploy.sh" --dry-run 2>&1
+)"
+legacy_status=$?
+set -euo pipefail
+
+if [ "$legacy_status" -ne 0 ]; then
+  echo "  PASS: dry-run exits non-zero on legacy template"
+  passes=$((passes + 1))
+else
+  echo "  FAIL: dry-run exited zero on legacy template"
+  failures=$((failures + 1))
+fi
+assert_contains "clear protocol error displayed" "Error: system deployment template does not support dry-run protocol." "$legacy_out"
+assert_contains "abort warning displayed" "Aborting to prevent unintentional live system modifications." "$legacy_out"
+assert_not_contains "legacy template was not executed" "LEGACY_EXECUTED" "$legacy_out"
+
+# Test 18: Combined wrapper (chezmoi-dry-apply) passes selected worktree source to both sides
+echo "Test 18: chezmoi-dry-apply passes worktree source to chezmoi apply and system deployment"
+CHEZMOI_LOG="$TEST_DIR/chezmoi_calls.log"
+cat << EOF > "$MOCK_BIN/chezmoi"
+#!/bin/bash
+if [ "\$1" = "source-path" ]; then
+  echo "$LEGACY_SOURCE"
+  exit 0
+fi
+if [[ " \$* " == *" apply "* ]]; then
+  echo "CHEZMOI_APPLY_ARGS: \$*" >> "$CHEZMOI_LOG"
+  exit 0
+fi
+exec "$REAL_CHEZMOI" "\$@"
+EOF
+chmod +x "$MOCK_BIN/chezmoi"
+
+DRY_APPLY_BIN="$REPO_ROOT/bin/executable_chezmoi-dry-apply"
+dry_apply_out="$(
+  cd "$FEATURE_WT"
+  PATH="$MOCK_BIN:$PATH" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DRY_APPLY_BIN"
+)"
+chezmoi_log_content="$(cat "$CHEZMOI_LOG")"
+assert_contains "chezmoi apply received worktree source" "-S $FEATURE_WT apply --dry-run" "$chezmoi_log_content"
+assert_contains "system deploy previewed worktree file" "feat-wt.conf" "$dry_apply_out"
 
 echo ""
 echo "Test results: $passes passed, $failures failed"

--- a/tests/test_system_deploy.sh
+++ b/tests/test_system_deploy.sh
@@ -206,46 +206,9 @@ SYSTEM_SOURCE_DIR="$SOURCE_DIR" SYSTEM_TARGET_DIR="$TARGET_DIR" "$DEPLOY_BIN" >/
 mode_after="$(stat -c "%a" "$TARGET_DIR/etc/nginx/conf.d/clean.conf")"
 assert_eq "file mode updated when metadata differed" "644" "$mode_after"
 
-# Test 13: Tracked Transmission source is preserved and not decommissioned
+# Test 13: Genuine decommissioned target is reported in dry run and removed in live mode
 if grep -q "report_stale" <<< "$check_rendered"; then
-  echo "Test 13: Tracked transmission source is preserved and not treated as decommissioned"
-  TRACKED_SRC="$TEST_DIR/tracked_trans_src"
-  TRACKED_TGT="$TEST_DIR/tracked_trans_tgt"
-  mkdir -p "$TRACKED_SRC/system/hetzner/etc/nginx/conf.d"
-  mkdir -p "$TRACKED_SRC/system/hetzner/etc/systemd/system/transmission.service.d"
-  echo "server { listen 9091; }" > "$TRACKED_SRC/system/hetzner/etc/nginx/conf.d/transmission.conf"
-  echo "[Service]" > "$TRACKED_SRC/system/hetzner/etc/systemd/system/transmission.service.d/override.conf"
-
-  mkdir -p "$TRACKED_TGT/etc/nginx/conf.d"
-  mkdir -p "$TRACKED_TGT/etc/systemd/system/transmission.service.d"
-  echo "old nginx config" > "$TRACKED_TGT/etc/nginx/conf.d/transmission.conf"
-  echo "old service dropin" > "$TRACKED_TGT/etc/systemd/system/transmission.service.d/override.conf"
-
-  # Dry-run: shows diff, does not report decommissioned
-  out_tracked_dry="$(SYSTEM_SOURCE_DIR="$TRACKED_SRC" SYSTEM_TARGET_DIR="$TRACKED_TGT" "$DEPLOY_BIN" --dry-run)"
-  assert_contains "diff shown for tracked transmission config" "diff --git a/etc/nginx/conf.d/transmission.conf b/etc/nginx/conf.d/transmission.conf" "$out_tracked_dry"
-  assert_not_contains "tracked nginx config not previewed as decommissioned" "[dry-run] would remove decommissioned transmission config: /etc/nginx/conf.d/transmission.conf" "$out_tracked_dry"
-  assert_not_contains "tracked dropin not previewed as decommissioned" "[dry-run] would remove decommissioned transmission config: /etc/systemd/system/transmission.service.d" "$out_tracked_dry"
-
-  # Live mode: updates target and does not remove
-  out_tracked_live="$(SYSTEM_SOURCE_DIR="$TRACKED_SRC" SYSTEM_TARGET_DIR="$TRACKED_TGT" "$DEPLOY_BIN")"
-  assert_contains "reports transmission config changed" "System file changed: /etc/nginx/conf.d/transmission.conf" "$out_tracked_live"
-  assert_not_contains "tracked nginx config not removed as decommissioned" "Removing decommissioned transmission config: /etc/nginx/conf.d/transmission.conf" "$out_tracked_live"
-  assert_not_contains "tracked dropin not removed as decommissioned" "Removing decommissioned transmission config: /etc/systemd/system/transmission.service.d" "$out_tracked_live"
-  if [ -f "$TRACKED_TGT/etc/nginx/conf.d/transmission.conf" ] && [ -f "$TRACKED_TGT/etc/systemd/system/transmission.service.d/override.conf" ]; then
-    echo "  PASS: tracked transmission configs exist in target after live deploy"
-    passes=$((passes + 1))
-  else
-    echo "  FAIL: tracked transmission configs missing after live deploy"
-    failures=$((failures + 1))
-  fi
-  tracked_content="$(cat "$TRACKED_TGT/etc/nginx/conf.d/transmission.conf")"
-  assert_contains "target was updated to tracked source content" "server { listen 9091; }" "$tracked_content"
-fi
-
-# Test 14: Genuine decommissioned target is reported in dry run and removed in live mode
-if grep -q "report_stale" <<< "$check_rendered"; then
-  echo "Test 14: Genuine decommissioned target reported in dry-run and removed in live mode"
+  echo "Test 13: Genuine decommissioned target reported in dry-run and removed in live mode"
   DECOM_SRC="$TEST_DIR/decom_src"
   DECOM_TGT="$TEST_DIR/decom_tgt"
   mkdir -p "$DECOM_SRC/system/hetzner" # No transmission configs in source
@@ -282,9 +245,9 @@ if grep -q "report_stale" <<< "$check_rendered"; then
   fi
 fi
 
-# Test 15: Non-writable DEST_ROOT cannot cause deletion of host /etc or call sudo
+# Test 14: Non-writable DEST_ROOT cannot escape to host /etc or call sudo
 if grep -q "report_stale" <<< "$check_rendered"; then
-  echo "Test 15: Non-writable DEST_ROOT cannot escape to host /etc or call sudo"
+  echo "Test 14: Non-writable DEST_ROOT cannot escape to host /etc or call sudo"
   RO_TGT="$TEST_DIR/ro_tgt"
   mkdir -p "$RO_TGT/etc/systemd/system/transmission-daemon.service.d"
   echo "stale daemon dropin" > "$RO_TGT/etc/systemd/system/transmission-daemon.service.d/override.conf"


### PR DESCRIPTION
## Summary

This PR adds a non-mutating dry-run inspection mode to `system-deploy.sh` / `run_after_system-deploy.sh.tmpl` as well as a new `chezmoi-dry-apply` wrapper command to preview full chezmoi dotfiles and system changes together.

### Key Changes
- **Dry-run mode in system deployment**:
  - Supports `-n`, `--dry-run`, and `DRY_RUN=1` / `SYSTEM_DEPLOY_DRY_RUN=1`.
  - Computes and displays Git-style unified diffs for existing `/etc` and `/usr` files without applying changes or requiring root write permissions.
  - Reports newly introduced files, permissions/mode changes, and ownership discrepancies.
  - Reports skipped services/reloads (e.g. nginx config test & reload).
- **`chezmoi-dry-apply` wrapper**:
  - Runs `chezmoi apply --dry-run --verbose` with arbitrary forwarded arguments to preview standard home dotfile changes.
  - Automatically chains into `system-deploy.sh --dry-run` for system-level configuration previews.
- **Tests & Documentation**:
  - Added test suites `tests/test_system_deploy.sh` and `tests/test_chezmoi_dry_apply.sh`.
  - Excluded test files from chezmoi deployment via `.chezmoiignore`.
  - Updated `README.md`, `markdown/features.md`, `markdown/tree.md`, and `AGENTS.md`.

## Test Plan
- [x] Ran `./tests/test_system_deploy.sh` (all assertions passed).
- [x] Ran `./tests/test_chezmoi_dry_apply.sh` (all assertions passed).
- [x] Ran `pre-commit run --all-files` (all checks passed).
- [x] Verified `bin/executable_system-deploy.sh --dry-run` against live system configuration.