### PR TITLE
docs(agents): enforce dedicated worktrees for non-main branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ Files ending in `.tmpl` are Go templates rendered by chezmoi. Template variables
 ## Conventions
 
 - NEVER KILL TMUX SERVER UNLESS I APPROVE
+- All non-main / feature branches must reside in their own dedicated git worktree (under `.worktrees/<branch-name>`), keeping the main repo directory clean on `main`
 - XDG Base Directory compliance throughout — most tools are configured to respect `$XDG_CONFIG_HOME`, `$XDG_DATA_HOME`, `$XDG_CACHE_HOME`
 - Git commits are GPG-signed (SSH key) per `dot_config/git/config`
 - Catppuccin Mocha is the color scheme used across tools (zsh syntax highlighting, Qtile themes, FZF)

--- a/dot_agents/AGENTS.md
+++ b/dot_agents/AGENTS.md
@@ -73,6 +73,12 @@ When you refer to types or very short code snippets, place them in
 backticks. When you have a full line of code or more than one line of
 code, put them in indented code blocks.
 
+### Git worktrees
+
+- All non-main / feature branches must reside in their own dedicated git worktree (typically under `.worktrees/<branch-name>`).
+- The primary repository directory must remain clean and checked out to the default branch (`main` or `master`).
+- Never develop or switch feature branches directly inside the primary repository directory.
+
 ## Documentation preferences
 
 ### Documentation examples

--- a/dot_pi/agent/AGENTS.md
+++ b/dot_pi/agent/AGENTS.md
@@ -15,3 +15,10 @@
   - Fall back to `google/gemini-3.8-flash` with `high` thinking.
   - Subagents automatically fall back to `google/gemini-3.8-flash:high` to complete delegated work.
   - The main session switches to `gemini-3.8-flash:high` for continued planning.
+
+## Git Worktree Policy
+
+- **Dedicated Worktrees for Branches**:
+  - All non-main / feature branches must reside in their own dedicated git worktree (typically under `.worktrees/<branch-name>`).
+  - The primary repository directory must remain clean and checked out to the default branch (`main` or `master`).
+  - Never switch branches or develop feature branches directly inside the primary repository checkout.

--- a/dot_pi/agent/APPEND_SYSTEM.md
+++ b/dot_pi/agent/APPEND_SYSTEM.md
@@ -10,3 +10,7 @@
   - If `gpt-5.6-sol` or `gpt-5.6-luna` reaches usage limits, rate limits, or is unavailable, immediately fall back to `google/gemini-3.8-flash` (thinking: `high`).
   - For the main session: switch planning to `gemini-3.8-flash:high` (or prompt `/model gemini-3.8-flash:high`).
   - For subagents: use `google/gemini-3.8-flash:high` as the automatic fallback model so execution continues without interruption.
+- **Git Worktree Policy**:
+  - All non-main / feature branches must reside in their own dedicated git worktree (e.g. `.worktrees/<branch-name>`).
+  - Keep the primary repository directory clean on the default branch (`main` or `master`).
+  - Never develop or switch feature branches directly inside the primary repository directory.


### PR DESCRIPTION
Enforces the policy that all non-main / feature branches must reside in their own dedicated git worktrees (e.g. `.worktrees/<branch-name>`), keeping primary repository checkouts clean on `main`.