### PR TITLE
Add SFTP viewer Nginx configuration

### DIFF
--- a/system/hetzner/etc/nginx/conf.d/sftp-viewer.conf
+++ b/system/hetzner/etc/nginx/conf.d/sftp-viewer.conf
@@ -1,0 +1,21 @@
+# SFTP Viewer mounted under the existing aslan HTTPS server.
+location = /sftp-viewer {
+    return 301 /sftp-viewer/;
+}
+
+location ^~ /sftp-viewer/ {
+    proxy_pass http://127.0.0.1:3022/;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    # Access authenticates at the edge; the app verifies this JWT.
+    proxy_set_header Cf-Access-Jwt-Assertion $http_cf_access_jwt_assertion;
+    proxy_set_header Connection "";
+    proxy_read_timeout 300s;
+    proxy_send_timeout 300s;
+    proxy_buffering off;
+    proxy_request_buffering off;
+}

--- a/system/hetzner/etc/nginx/nginx.conf
+++ b/system/hetzner/etc/nginx/nginx.conf
@@ -62,8 +62,8 @@ http {
         more_clear_headers Server;
         server_name sftp.archnet.lol;
 
-        ssl_certificate /etc/letsencrypt/live/sftp.archnet.lol/fullchain.pem;
-        ssl_certificate_key /etc/letsencrypt/live/sftp.archnet.lol/privkey.pem;
+        ssl_certificate /etc/ssl/certs/sftp.archnet.lol-origin.pem;
+        ssl_certificate_key /etc/ssl/private/sftp.archnet.lol-origin.key;
         ssl_protocols TLSv1.2 TLSv1.3;
         ssl_prefer_server_ciphers on;
 

--- a/system/hetzner/etc/nginx/nginx.conf
+++ b/system/hetzner/etc/nginx/nginx.conf
@@ -30,12 +30,42 @@ http {
         '' close;
     }
 
-    # Redirect HTTP to HTTPS
+    # Redirect HTTP to HTTPS for web hosts.
     server {
         listen 80;
         listen [::]:80;
-        server_name aslan.archnet.lol archen.archnet.lol;
+        server_name aslan.archnet.lol archen.archnet.lol sftp.archnet.lol;
         return 301 https://$host$request_uri;
+    }
+
+    server {
+        listen 443 ssl;
+        http2 on;
+        listen [::]:443 ssl;
+        more_clear_headers Server;
+        server_name sftp.archnet.lol;
+
+        ssl_certificate /etc/letsencrypt/live/sftp.archnet.lol/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/sftp.archnet.lol/privkey.pem;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_prefer_server_ciphers on;
+
+        location / {
+            proxy_pass http://127.0.0.1:3022/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header X-Forwarded-Host $host;
+            # Access authenticates at the edge; the app verifies this JWT.
+            proxy_set_header Cf-Access-Jwt-Assertion $http_cf_access_jwt_assertion;
+            proxy_set_header Connection "";
+            proxy_read_timeout 300s;
+            proxy_send_timeout 300s;
+            proxy_buffering off;
+            proxy_request_buffering off;
+        }
     }
 
     server {

--- a/system/hetzner/etc/nginx/nginx.conf
+++ b/system/hetzner/etc/nginx/nginx.conf
@@ -38,6 +38,23 @@ http {
         return 301 https://$host$request_uri;
     }
 
+    # ssh.archnet.lol is reserved for SSH on TCP/22. Reject web traffic
+    # explicitly instead of falling through to another virtual host.
+    server {
+        listen 80;
+        listen [::]:80;
+        server_name ssh.archnet.lol;
+        return 444;
+    }
+
+    server {
+        listen 443 ssl;
+        http2 on;
+        listen [::]:443 ssl;
+        server_name ssh.archnet.lol;
+        ssl_reject_handshake on;
+    }
+
     server {
         listen 443 ssl;
         http2 on;


### PR DESCRIPTION
## Summary
- proxy the SFTP viewer through Nginx on port 3022
- add the sftp.archnet.lol virtual host configuration
- reject web traffic for ssh.archnet.lol while preserving SSH on port 22

## Validation
- `git diff --check origin/main...feat/sftp-viewer`