### PR TITLE
docs(pi): clarify subagent execution policy

### DIFF
--- a/dot_pi/agent/AGENTS.md
+++ b/dot_pi/agent/AGENTS.md
@@ -7,7 +7,13 @@
   - The main session does not perform direct implementation or write code/tests. It designs the plan, frames the requirements, evaluates trade-offs, and delegates work.
 - **Subagents (Implementation & Work)**:
   - Role: Execution and Workers.
-  - All file changes, coding, test execution, debugging, and mechanical tasks are carried out by subagents running on `gpt-5.6-luna:high`.
+  - All file changes, coding, test execution, debugging, and mechanical tasks are carried out by worker subagents using `openai-codex/gpt-5.6-luna:high` until Luna reaches its usage limit; then use the configured `google/gemini-3.8-flash:high` fallback.
+
+## Subagent Launch Policy
+
+- Prefer async/background subagent execution.
+- When a direct single-child async launch is unavailable or fails, wrap that one worker in an async workflow using `workflowScript` with one `runs.run` call, and launch the workflow with `async: true`; this preserves background execution even for one worker.
+- Only fall back to foreground execution with fork context if both the direct async launch and the single-worker async workflow approach fail or are unavailable.
 
 ## Fallback Policy
 


### PR DESCRIPTION
## Summary
- Clarify that file changes, coding, test execution, debugging, and mechanical tasks run through worker subagents using `openai-codex/gpt-5.6-luna:high`, with the configured `google/gemini-3.8-flash:high` fallback after Luna limits or unavailability.
- Add the subagent launch policy: prefer async/background execution, use a one-worker async workflow when direct async launch is unavailable, and use foreground fork execution only as the final fallback.

## Validation
- `git diff --check main...HEAD` passed.
- `git diff --stat main...HEAD` confirms one changed file with 7 insertions and 1 deletion.
- The amended commit is signed and was pushed with `--force-with-lease`.
- PR base/head and remote branch were verified after the update.