### PR TITLE
fix(calibre): enforce Cloudflare-only access

### DIFF
--- a/system/hetzner/etc/nginx/conf.d/calibre-server.conf
+++ b/system/hetzner/etc/nginx/conf.d/calibre-server.conf
@@ -1,9 +1,17 @@
 proxy_set_header X-Forwarded-For $remote_addr;
 location /calibre/ {
+    # Access is the user-authentication boundary. Reject direct-origin
+    # requests whose TCP peer is not a Cloudflare proxy.
+    if ($calibre_cloudflare_peer = 0) {
+        return 403;
+    }
     proxy_buffering off;
     proxy_pass http://$calibre/$request_uri;
 }
 location /calibre {
     # we need a trailing slash for the Application Cache to work
+    if ($calibre_cloudflare_peer = 0) {
+        return 403;
+    }
     rewrite /calibre /calibre/ permanent;
 }

--- a/system/hetzner/etc/nginx/nginx.conf
+++ b/system/hetzner/etc/nginx/nginx.conf
@@ -30,6 +30,38 @@ http {
         '' close;
     }
 
+    # Calibre must only be reachable through a Cloudflare proxy. This checks
+    # the actual TCP peer preserved by ngx_http_realip_module, not a header.
+    geo $realip_remote_addr $calibre_cloudflare_peer {
+        default 0;
+
+        # Cloudflare IPv4 proxy ranges.
+        173.245.48.0/20 1;
+        103.21.244.0/22 1;
+        103.22.200.0/22 1;
+        103.31.4.0/22 1;
+        141.101.64.0/18 1;
+        108.162.192.0/18 1;
+        190.93.240.0/20 1;
+        188.114.96.0/20 1;
+        197.234.240.0/22 1;
+        198.41.128.0/17 1;
+        162.158.0.0/15 1;
+        104.16.0.0/13 1;
+        104.24.0.0/14 1;
+        172.64.0.0/13 1;
+        131.0.72.0/22 1;
+
+        # Cloudflare IPv6 proxy ranges.
+        2400:cb00::/32 1;
+        2606:4700::/32 1;
+        2803:f800::/32 1;
+        2405:b500::/32 1;
+        2405:8100::/32 1;
+        2a06:98c0::/29 1;
+        2c0f:f248::/32 1;
+    }
+
     # Redirect HTTP to HTTPS for web hosts.
     server {
         listen 80;

--- a/system/hetzner/etc/systemd/system/calibre-server.service.d/override.conf
+++ b/system/hetzner/etc/systemd/system/calibre-server.service.d/override.conf
@@ -7,7 +7,7 @@ After=network-online.target
 User=calibre
 Group=calibre
 ExecStart=
-ExecStart=/usr/bin/calibre-server --port 8080 --url-prefix /calibre --enable-auth --userdb /srv/calibre/users.sqlite --access-log /srv/calibre/access.log --auth-mode basic /srv/calibre/
+ExecStart=/usr/bin/calibre-server --listen-on 127.0.0.1 --port 8080 --url-prefix /calibre --access-log /srv/calibre/access.log /srv/calibre/
 Type=simple
 
 [Install]


### PR DESCRIPTION
## Summary
- disable Calibre internal password authentication
- bind Calibre to loopback so port 8080 cannot bypass Cloudflare Access
- deny direct-origin `/calibre` requests unless the TCP peer is a Cloudflare proxy

## Validation
- `nginx -t` passed
- Calibre restarted successfully
- direct origin `:8080` refused
- direct origin HTTPS `/calibre/` returns 403
- public `/calibre/` redirects to Cloudflare Access
- local Calibre responds 200 without `WWW-Authenticate`

Not merged.