### PR TITLE
fix(nginx): restore Laura HTTPS after SSH reject

### DIFF
--- a/system/hetzner/etc/nginx/nginx.conf
+++ b/system/hetzner/etc/nginx/nginx.conf
@@ -64,9 +64,9 @@ http {
 
     # Redirect HTTP to HTTPS for web hosts.
     server {
-        listen 80;
-        listen [::]:80;
-        server_name aslan.archnet.lol archen.archnet.lol sftp.archnet.lol;
+        listen 80 default_server;
+        listen [::]:80 default_server;
+        server_name aslan.archnet.lol archen.archnet.lol sftp.archnet.lol laura-photos.com www.laura-photos.com;
         return 301 https://$host$request_uri;
     }
 
@@ -118,11 +118,11 @@ http {
     }
 
     server {
-        listen 443 ssl;
+        listen 443 ssl default_server;
         http2 on;
-        listen [::]:443 ssl;
+        listen [::]:443 ssl default_server;
         more_clear_headers Server;
-        server_name aslan.archnet.lol;
+        server_name aslan.archnet.lol laura-photos.com www.laura-photos.com;
 
         ssl_certificate /etc/letsencrypt/live/aslan.archnet.lol/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/aslan.archnet.lol/privkey.pem;


### PR DESCRIPTION
Make the Aslan HTTPS vhost the explicit default for IPv4 and IPv6.

The SSH hostname remains an explicit rejecting vhost. Unknown SNI, including laura-photos.com, now falls through to the existing Aslan routing instead of failing TLS with Cloudflare 525.

Validated with nginx -t, public Laura HTTPS, direct origin TLS SNI, and SSH rejection.