### PR TITLE
fix(zsh): preserve zsh-abbr expand-on-space keybinding

### DIFF
--- a/dot_config/zsh/dot_zshrc.tmpl
+++ b/dot_config/zsh/dot_zshrc.tmpl
@@ -68,3 +68,9 @@ source "$ZDOTDIR/rc/misc.zsh"
 {{ if ne .machine "cloudtop" -}}
 source "$ZDOTDIR/rc/hooks.zsh"
 {{ end -}}
+
+# Ensure zsh-abbr keybindings remain active after all modules/plugins load
+if (( $+widgets[abbr-expand-and-insert] )); then
+    bindkey ' ' abbr-expand-and-insert
+    bindkey '^ ' magic-space
+fi

--- a/dot_config/zsh/rc/keys.zsh.tmpl
+++ b/dot_config/zsh/rc/keys.zsh.tmpl
@@ -10,7 +10,12 @@ lfcd() {
 }
 
 bindkey -e                                     # emacs key bindings
-bindkey ' ' magic-space                        # do history expansion on space
+if (( $+widgets[abbr-expand-and-insert] )); then
+    bindkey ' ' abbr-expand-and-insert
+    bindkey '^ ' magic-space
+else
+    bindkey ' ' magic-space
+fi
 bindkey '^[[3;5~' kill-word                    # ctrl + Supr
 bindkey '^[[3~' delete-char                    # delete
 bindkey '^[[1;5C' forward-word                 # ctrl + ->
@@ -56,7 +61,12 @@ lfcd () {
 
 # configure key keybindings
 bindkey -e                                        # emacs key bindings
-bindkey ' ' magic-space                           # do history expansion on space
+if (( $+widgets[abbr-expand-and-insert] )); then
+    bindkey ' ' abbr-expand-and-insert
+    bindkey '^ ' magic-space
+else
+    bindkey ' ' magic-space
+fi
 {{ if eq .chezmoi.os "darwin" -}}
 bindkey '^[[3~' backward-delete-word              # delete
 bindkey '^[[4~' forward-word                      # fn + ->


### PR DESCRIPTION
## Summary
- preserve zsh-abbr\x27s Space expansion binding in both machine branches
- retain history expansion through Ctrl+Space when zsh-abbr is available
- reassert zsh-abbr bindings after all Zsh modules and plugins load

## Validation
- rendered both templates with chezmoi using the feature worktree as source
- checked rendered files with `zsh -n`
- verified Space and Ctrl+Space bindings and `gst` expansion to `git status` in interactive Zsh
- `git diff --check` passed