### PR TITLE
feat(pi): add tmux inspector extension and pi-subagents fleet patch

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -7,6 +7,7 @@ tmp
 configs
 docs/**
 system/**
+patches/**
 tests/**
 markdown/**
 secrets.age

--- a/dot_pi/private_agent/extensions/subagent-tmux-inspector.ts
+++ b/dot_pi/private_agent/extensions/subagent-tmux-inspector.ts
@@ -1,0 +1,281 @@
+import type {
+	ExtensionAPI,
+	ExtensionContext,
+} from "@earendil-works/pi-coding-agent";
+import { execFile } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+interface RunInfo {
+	id: string;
+	shortId: string;
+	asyncDir: string;
+	outputFile: string;
+	state: string;
+	name: string;
+	startedAt?: string;
+	active: boolean;
+	cwd: string;
+}
+
+function getAsyncDirRoot(): string {
+	const uid = process.getuid ? process.getuid() : "unknown";
+	return path.join(
+		os.tmpdir(),
+		`pi-subagents-uid-${uid}`,
+		"async-subagent-runs",
+	);
+}
+
+function findInspectorRunner(): string | undefined {
+	const candidate = path.join(
+		os.homedir(),
+		".pi/agent/npm/node_modules/pi-subagents/inspector-runner.mjs",
+	);
+	return fs.existsSync(candidate) ? candidate : undefined;
+}
+
+function getAvailableRuns(): RunInfo[] {
+	const root = getAsyncDirRoot();
+	if (!fs.existsSync(root)) return [];
+
+	const activeDir = path.join(root, ".active-runs");
+	const activeIds = new Set<string>();
+	if (fs.existsSync(activeDir)) {
+		try {
+			for (const file of fs.readdirSync(activeDir)) {
+				if (!file.startsWith(".") && file !== "tool-calls") {
+					activeIds.add(file);
+				}
+			}
+		} catch (_err) {
+			void _err;
+		}
+	}
+
+	const entries = fs.readdirSync(root).filter((f) => !f.startsWith("."));
+	const runs: RunInfo[] = [];
+
+	for (const runId of entries) {
+		const runDir = path.join(root, runId);
+		try {
+			if (!fs.statSync(runDir).isDirectory()) continue;
+			const statusPath = path.join(runDir, "status.json");
+			let state = "unknown";
+			let name = "";
+			let startedAt: string | undefined;
+			let cwd = process.cwd();
+
+			if (fs.existsSync(statusPath)) {
+				const status = JSON.parse(fs.readFileSync(statusPath, "utf8"));
+				state = status.state || "unknown";
+				cwd = status.cwd || cwd;
+				if (status.startedAt) {
+					startedAt = new Date(status.startedAt).toLocaleTimeString();
+				}
+				if (status.steps && status.steps[0]) {
+					name =
+						status.steps[0].sessionName ||
+						status.steps[0].agent ||
+						status.steps[0].description ||
+						"";
+				}
+			}
+
+			const outputFile = path.join(runDir, "output-0.log");
+			runs.push({
+				id: runId,
+				shortId: runId.slice(0, 8),
+				asyncDir: runDir,
+				outputFile,
+				state,
+				name,
+				startedAt,
+				active: activeIds.has(runId) || state === "running",
+				cwd,
+			});
+		} catch (_err) {
+			void _err;
+		}
+	}
+
+	// Sort active runs first, then newest
+	runs.sort((a, b) => {
+		if (a.active && !b.active) return -1;
+		if (!a.active && b.active) return 1;
+		return 0;
+	});
+
+	return runs;
+}
+
+async function openInTmux(
+	run: RunInfo,
+	options: { split?: boolean } = {},
+): Promise<string> {
+	if (!process.env.TMUX) {
+		throw new Error("tmux is not running ($TMUX is not set).");
+	}
+
+	const runnerPath = findInspectorRunner();
+	if (!runnerPath) {
+		throw new Error("Could not find pi-subagents/inspector-runner.mjs");
+	}
+
+	const windowName = `subagent-${run.shortId}`;
+
+	// Check if a window with this name already exists
+	try {
+		const { stdout } = await execFileAsync("tmux", [
+			"list-windows",
+			"-F",
+			"#{window_name}:#{window_id}",
+		]);
+		for (const line of stdout.split("\n")) {
+			const [name, wid] = line.trim().split(":");
+			if (name === windowName && wid) {
+				await execFileAsync("tmux", ["select-window", "-t", wid]);
+				return `Switched to existing tmux window ${wid} (${windowName})`;
+			}
+		}
+	} catch (_err) {
+		void _err;
+	}
+
+	const inspectorCmd = `"${process.execPath}" "${runnerPath}" --async-dir "${run.asyncDir}" --run-id "${run.id}" --allow-steer true --allow-stop true`;
+	const outputLogCmd = `sh -c 'while [ ! -f "${run.outputFile}" ]; do sleep 0.2; done; less +F "${run.outputFile}"; exec $SHELL'`;
+
+	if (options.split) {
+		// Split current window horizontally
+		const { stdout: paneId } = await execFileAsync("tmux", [
+			"split-window",
+			"-h",
+			"-P",
+			"-F",
+			"#{pane_id}",
+			"-c",
+			run.cwd,
+			inspectorCmd,
+		]);
+		await execFileAsync("tmux", ["select-pane", "-t", paneId.trim()]);
+		return `Opened subagent ${run.shortId} in split pane ${paneId.trim()}`;
+	}
+
+	// Create new window
+	const { stdout: winOut } = await execFileAsync("tmux", [
+		"new-window",
+		"-P",
+		"-F",
+		"#{window_id}",
+		"-n",
+		windowName,
+		"-c",
+		run.cwd,
+		inspectorCmd,
+	]);
+	const windowId = winOut.trim();
+
+	// Split right pane to display the full output stream
+	try {
+		await execFileAsync("tmux", [
+			"split-window",
+			"-h",
+			"-t",
+			windowId,
+			"-c",
+			run.cwd,
+			outputLogCmd,
+		]);
+	} catch (_splitErr) {
+		void _splitErr;
+	}
+
+	// Focus the window directly in front of the user
+	await execFileAsync("tmux", ["select-window", "-t", windowId]);
+	await execFileAsync("tmux", ["select-pane", "-t", `${windowId}.1`]);
+
+	return `Opened subagent ${run.shortId} in new window ${windowId} (Left: Read-Only Dashboard, Right: Full Output)`;
+}
+
+export default function (pi: ExtensionAPI) {
+	const handleInspect = async (
+		rawArgs: string,
+		ctx: { ui: ExtensionContext["ui"] },
+	) => {
+		const args = rawArgs.trim();
+		const splitMode = args.includes("--split") || args.includes("-s");
+		const targetId = args.replace("--split", "").replace("-s", "").trim();
+
+		const runs = getAvailableRuns();
+		if (runs.length === 0) {
+			ctx.ui.notify("No subagent runs found.", "error");
+			return;
+		}
+
+		let chosenRun: RunInfo | undefined;
+
+		if (targetId) {
+			chosenRun = runs.find(
+				(r) =>
+					r.id === targetId || r.shortId === targetId || r.id.startsWith(targetId),
+			);
+			if (!chosenRun) {
+				ctx.ui.notify(`No subagent run matching '${targetId}' found.`, "error");
+				return;
+			}
+		} else {
+			const activeRuns = runs.filter((r) => r.active);
+			if (activeRuns.length === 1) {
+				chosenRun = activeRuns[0];
+			} else {
+				const options = runs.slice(0, 10).map((r) => {
+					const badge = r.active ? "● [running]" : "○ [settled]";
+					const title = r.name ? ` — ${r.name.slice(0, 45)}` : "";
+					return `${badge} ${r.shortId}${title}`;
+				});
+
+				const selected = await ctx.ui.select(
+					"Select subagent run to inspect in tmux:",
+					options,
+				);
+				if (!selected) return;
+
+				const selectedShortId = selected.split(" ")[1]?.trim();
+				chosenRun = runs.find((r) => r.shortId === selectedShortId);
+			}
+		}
+
+		if (!chosenRun) return;
+
+		try {
+			const msg = await openInTmux(chosenRun, { split: splitMode });
+			ctx.ui.notify(msg, "info");
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			ctx.ui.notify(`Failed to open tmux inspector: ${message}`, "error");
+		}
+	};
+
+	pi.registerCommand("subagent-inspect", {
+		description:
+			"Open subagent in new tmux window/pane with read-only dashboard & full output",
+		handler: handleInspect,
+	});
+
+	pi.registerCommand("subagent-view", {
+		description:
+			"Alias for /subagent-inspect: open subagent in tmux with read-only dashboard & full output",
+		handler: handleInspect,
+	});
+
+	pi.registerShortcut("ctrl+alt+i", {
+		description: "Open active subagent in new tmux inspector window",
+		handler: async (ctx) => {
+			await handleInspect("", ctx);
+		},
+	});
+}

--- a/patches/pi-subagents/tmux/actions.ts
+++ b/patches/pi-subagents/tmux/actions.ts
@@ -1,0 +1,311 @@
+import { execFile, type ExecFileOptionsWithStringEncoding } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AgentToolResult } from "@earendil-works/pi-agent-core";
+import { writeAtomicJson } from "../../shared/atomic-json.ts";
+import type { Details } from "../../shared/types.ts";
+import type { InspectorContext, InspectorLaunch, InspectorParams, InspectorTarget } from "../types.ts";
+
+export interface TmuxInspectorBinding {
+	schemaVersion: 1;
+	kind: "tmux-inspector";
+	runId: string;
+	asyncDir: string;
+	childIndex?: number;
+	missionId?: string;
+	missionPath?: string;
+	windowId?: string;
+	paneId: string;
+	outputPaneId?: string;
+	openedAt: string;
+	lastFocusedAt?: string;
+	command: string;
+}
+
+export function bindingPath(asyncDir: string, index?: number): string {
+	return path.join(asyncDir, "inspectors", `tmux${index === undefined ? "" : `-${index}`}.json`);
+}
+
+function parse(value: unknown): TmuxInspectorBinding | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const binding = value as Partial<TmuxInspectorBinding>;
+	if (
+		binding.schemaVersion !== 1 ||
+		binding.kind !== "tmux-inspector" ||
+		(binding.childIndex !== undefined && (!Number.isInteger(binding.childIndex) || binding.childIndex < 0)) ||
+		typeof binding.runId !== "string" ||
+		typeof binding.asyncDir !== "string" ||
+		typeof binding.paneId !== "string" ||
+		typeof binding.openedAt !== "string" ||
+		typeof binding.command !== "string"
+	)
+		return undefined;
+	return binding as TmuxInspectorBinding;
+}
+
+export function readTmuxInspectorBinding(asyncDir: string, index?: number): TmuxInspectorBinding | undefined {
+	try {
+		return parse(JSON.parse(fs.readFileSync(bindingPath(asyncDir, index), "utf8")));
+	} catch (_err) {
+		void _err;
+		return undefined;
+	}
+}
+
+export function readTmuxInspectorBindingForTarget(target: InspectorTarget): TmuxInspectorBinding | undefined {
+	const binding = readTmuxInspectorBinding(target.asyncDir, target.index);
+	if (!binding || binding.runId !== target.runId || binding.childIndex !== target.index) return undefined;
+	try {
+		if (fs.realpathSync(binding.asyncDir) !== fs.realpathSync(target.asyncDir)) return undefined;
+	} catch (_err) {
+		void _err;
+		return undefined;
+	}
+	return binding;
+}
+
+function result(text: string, isError = false): AgentToolResult<Details> {
+	return {
+		content: [{ type: "text", text }],
+		...(isError ? { isError: true } : {}),
+		details: { mode: "management", results: [] },
+	};
+}
+
+export type TmuxRunner = (
+	args: readonly string[],
+	options?: ExecFileOptionsWithStringEncoding,
+) => Promise<{ stdout: string; stderr: string }>;
+
+function defaultRunner(
+	args: readonly string[],
+	options: ExecFileOptionsWithStringEncoding = { encoding: "utf8" },
+): Promise<{ stdout: string; stderr: string }> {
+	return new Promise((resolve, reject) => {
+		execFile("tmux", [...args], options, (error, stdout, stderr) => {
+			if (error) {
+				const failure = error instanceof Error ? error : new Error(String(error));
+				reject(failure);
+				return;
+			}
+			resolve({ stdout: String(stdout), stderr: String(stderr) });
+		});
+	});
+}
+
+async function isWindowAlive(runner: TmuxRunner, windowId: string): Promise<boolean> {
+	try {
+		const { stdout } = await runner(["list-windows", "-F", "#{window_id}"]);
+		return stdout
+			.split("\n")
+			.map((line) => line.trim())
+			.includes(windowId.trim());
+	} catch (_err) {
+		void _err;
+		return false;
+	}
+}
+
+async function isPaneAlive(runner: TmuxRunner, paneId: string): Promise<boolean> {
+	try {
+		const { stdout } = await runner(["list-panes", "-a", "-F", "#{pane_id}"]);
+		return stdout
+			.split("\n")
+			.map((line) => line.trim())
+			.includes(paneId.trim());
+	} catch (_err) {
+		void _err;
+		return false;
+	}
+}
+
+export async function openTmuxInspector(
+	context: InspectorContext,
+	launch: InspectorLaunch,
+	params: InspectorParams,
+	runner: TmuxRunner = defaultRunner,
+): Promise<AgentToolResult<Details>> {
+	const existing = readTmuxInspectorBindingForTarget(context.target);
+	if (existing) {
+		if (existing.windowId && (await isWindowAlive(runner, existing.windowId))) {
+			if (params.focus !== false) {
+				try {
+					await runner(["select-window", "-t", existing.windowId]);
+					await runner(["select-pane", "-t", existing.paneId]);
+				} catch (_err) {
+					void _err;
+				}
+			}
+			return result(
+				`Refocused existing read-only tmux inspector window ${existing.windowId} for async run ${context.target.runId}.`,
+			);
+		}
+		if (existing.paneId && (await isPaneAlive(runner, existing.paneId))) {
+			if (params.focus !== false) {
+				try {
+					await runner(["select-pane", "-t", existing.paneId]);
+				} catch (_err) {
+					void _err;
+				}
+			}
+			return result(
+				`Refocused existing read-only tmux inspector pane ${existing.paneId} for async run ${context.target.runId}.`,
+			);
+		}
+	}
+
+	const shortId = context.target.runId.slice(0, 8);
+	const windowName = `subagent-${shortId}${context.target.index !== undefined ? `-${context.target.index}` : ""}`;
+	const launchCwd = context.target.status.cwd ?? context.cwd;
+
+	const outputPath =
+		context.target.index !== undefined
+			? path.join(context.target.asyncDir, `output-${context.target.index}.log`)
+			: path.join(context.target.asyncDir, "output-0.log");
+
+	const mode =
+		context.env.PI_INSPECTOR_TMUX_MODE?.toLowerCase() === "split" ? "split" : "window";
+
+	try {
+		let windowId: string | undefined;
+		let paneId: string;
+		let outputPaneId: string | undefined;
+
+		if (mode === "split") {
+			const splitResult = await runner([
+				"split-window",
+				"-h",
+				"-P",
+				"-F",
+				"#{pane_id}",
+				"-c",
+				launchCwd,
+				launch.displayCommand,
+			]);
+			paneId = splitResult.stdout.trim();
+			if (params.focus !== false) {
+				await runner(["select-pane", "-t", paneId]);
+			}
+		} else {
+			const newWinResult = await runner([
+				"new-window",
+				"-P",
+				"-F",
+				"#{window_id}:#{pane_id}",
+				"-n",
+				windowName,
+				"-c",
+				launchCwd,
+				launch.displayCommand,
+			]);
+			const [wId, pId] = newWinResult.stdout.trim().split(":");
+			windowId = wId;
+			paneId = pId;
+
+			// Split right pane to show full output stream
+			try {
+				const outputCmd = `sh -c 'while [ ! -f "${outputPath}" ]; do sleep 0.2; done; less +F "${outputPath}"; exec $SHELL'`;
+				const splitResult = await runner([
+					"split-window",
+					"-h",
+					"-P",
+					"-F",
+					"#{pane_id}",
+					"-t",
+					windowId,
+					"-c",
+					launchCwd,
+					outputCmd,
+				]);
+				outputPaneId = splitResult.stdout.trim();
+			} catch (_splitErr) {
+				void _splitErr;
+			}
+
+			// Focus the window directly in front of the user
+			if (params.focus !== false) {
+				await runner(["select-window", "-t", windowId]);
+				await runner(["select-pane", "-t", paneId]);
+			}
+		}
+
+		const now = (context.now?.() ?? new Date()).toISOString();
+		const binding: TmuxInspectorBinding = {
+			schemaVersion: 1,
+			kind: "tmux-inspector",
+			runId: context.target.runId,
+			asyncDir: context.target.asyncDir,
+			...(context.target.index === undefined ? {} : { childIndex: context.target.index }),
+			...(launch.mission ? { missionId: launch.mission.id, missionPath: launch.mission.path } : {}),
+			...(windowId ? { windowId } : {}),
+			paneId,
+			...(outputPaneId ? { outputPaneId } : {}),
+			openedAt: now,
+			...(params.focus !== false ? { lastFocusedAt: now } : {}),
+			command: launch.displayCommand,
+		};
+		writeAtomicJson(bindingPath(context.target.asyncDir, context.target.index), binding);
+
+		const targetDesc = windowId
+			? `window ${windowId} (${windowName})`
+			: `pane ${paneId}`;
+		const layoutDesc = outputPaneId
+			? "Left pane: interactive read-only inspector dashboard. Right pane: full output log viewer (less +F)."
+			: "Interactive read-only inspector dashboard.";
+
+		return result(
+			`Opened read-only tmux inspector ${targetDesc} for async run ${context.target.runId}.\n${layoutDesc}\nClosing the window/pane does not stop the run.`,
+		);
+	} catch (cause) {
+		const message = cause instanceof Error ? cause.message : String(cause);
+		return result(`Tmux inspector error: ${message}`, true);
+	}
+}
+
+export async function statusTmuxInspector(
+	context: InspectorContext,
+	runner: TmuxRunner = defaultRunner,
+): Promise<AgentToolResult<Details>> {
+	const binding = readTmuxInspectorBindingForTarget(context.target);
+	if (!binding) {
+		return result(
+			`No tmux inspector binding exists for async run ${context.target.runId}${context.target.index === undefined ? "" : ` child ${context.target.index}`}.`,
+		);
+	}
+	const alive = binding.windowId
+		? await isWindowAlive(runner, binding.windowId)
+		: await isPaneAlive(runner, binding.paneId);
+
+	if (!alive) {
+		return result(
+			`Tmux inspector ${binding.windowId ?? binding.paneId} is no longer running.\nRun state remains authoritative: ${context.target.status.state}.`,
+			true,
+		);
+	}
+	return result(
+		`Tmux inspector ${binding.windowId ?? binding.paneId} is active for async run ${context.target.runId}.\nRun state: ${context.target.status.state}\nBinding: ${bindingPath(context.target.asyncDir, context.target.index)}`,
+	);
+}
+
+export async function closeTmuxInspector(
+	context: InspectorContext,
+	runner: TmuxRunner = defaultRunner,
+): Promise<AgentToolResult<Details>> {
+	const binding = readTmuxInspectorBindingForTarget(context.target);
+	if (!binding) {
+		return result(`No tmux inspector binding exists for async run ${context.target.runId}.`);
+	}
+	try {
+		if (binding.windowId) {
+			await runner(["kill-window", "-t", binding.windowId]);
+		} else {
+			await runner(["kill-pane", "-t", binding.paneId]);
+		}
+	} catch (_err) {
+		void _err;
+	}
+	fs.rmSync(bindingPath(context.target.asyncDir, context.target.index), { force: true });
+	return result(
+		`Closed tmux inspector ${binding.windowId ?? binding.paneId} for async run ${context.target.runId}. The subagent run was not stopped.`,
+	);
+}

--- a/patches/pi-subagents/tmux/plugin.ts
+++ b/patches/pi-subagents/tmux/plugin.ts
@@ -1,0 +1,23 @@
+import {
+	closeTmuxInspector,
+	openTmuxInspector,
+	readTmuxInspectorBindingForTarget,
+	statusTmuxInspector,
+	type TmuxRunner,
+} from "./actions.ts";
+import type { InspectorPlugin } from "../types.ts";
+
+export interface TmuxPluginDeps {
+	runner?: TmuxRunner;
+}
+
+export function createTmuxInspectorPlugin(deps: TmuxPluginDeps = {}): InspectorPlugin {
+	return {
+		name: "tmux",
+		available: (context) => Boolean(context.env.TMUX),
+		owns: (context) => readTmuxInspectorBindingForTarget(context.target) !== undefined,
+		open: (context, launch, params) => openTmuxInspector(context, launch, params, deps.runner),
+		status: (context) => statusTmuxInspector(context, deps.runner),
+		close: (context) => closeTmuxInspector(context, deps.runner),
+	};
+}

--- a/run_after_patch-pi-subagents.sh.tmpl
+++ b/run_after_patch-pi-subagents.sh.tmpl
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -euo pipefail
+
+SUBAGENTS_DIR="$HOME/.pi/agent/npm/node_modules/pi-subagents"
+[ -d "$SUBAGENTS_DIR" ] || exit 0
+
+PLUGINS_FILE="$SUBAGENTS_DIR/src/inspectors/plugins.ts"
+TMUX_DIR="$SUBAGENTS_DIR/src/inspectors/tmux"
+SOURCE_PATCH_DIR="{{ .chezmoi.sourceDir }}/patches/pi-subagents/tmux"
+
+[ -d "$SOURCE_PATCH_DIR" ] || exit 0
+
+# 1. Copy tmux inspector actions and plugin definitions
+mkdir -p "$TMUX_DIR"
+cp "$SOURCE_PATCH_DIR/actions.ts" "$TMUX_DIR/actions.ts"
+cp "$SOURCE_PATCH_DIR/plugin.ts" "$TMUX_DIR/plugin.ts"
+
+# 2. Patch plugins.ts to register createTmuxInspectorPlugin if not already present
+if [ -f "$PLUGINS_FILE" ] && ! grep -q "createTmuxInspectorPlugin" "$PLUGINS_FILE"; then
+  node -e '
+    const fs = require("fs");
+    const file = process.argv[1];
+    let content = fs.readFileSync(file, "utf8");
+    if (!content.includes("createTmuxInspectorPlugin")) {
+      content = content.replace(
+        `import { createGhosttyInspectorPlugin } from "./ghostty/plugin.ts";`,
+        `import { createTmuxInspectorPlugin } from "./tmux/plugin.ts";\nimport { createGhosttyInspectorPlugin } from "./ghostty/plugin.ts";`
+      );
+      content = content.replace(
+        `return [createHerdrInspectorPlugin(), createGhosttyInspectorPlugin()];`,
+        `return [createHerdrInspectorPlugin(), createTmuxInspectorPlugin(), createGhosttyInspectorPlugin()];`
+      );
+      fs.writeFileSync(file, content, "utf8");
+      console.log("Patched " + file + " with createTmuxInspectorPlugin");
+    }
+  ' "$PLUGINS_FILE"
+fi


### PR DESCRIPTION
## Summary

- Add the `/subagent-inspect` command, `/subagent-view` alias, and `Ctrl+Alt+I` shortcut to open subagent runs in tmux with a read-only dashboard and full output log.
- Add the pi-subagents tmux inspector implementation for window/pane lifecycle, durable bindings, refocus, status, and close operations without stopping the run.
- Add a chezmoi post-apply hook to install and register the patch, while keeping patch source assets out of deployed home files.

## Validation

- `git diff --check 1fcc2b8..fa331c7` passed.
- `bash -n run_after_patch-pi-subagents.sh.tmpl` passed.
- Branch worktree was clean before push.
