### PR TITLE
fix(systemd): pin job applier database path

### DIFF
--- a/dot_config/systemd/user/job-applier.service
+++ b/dot_config/systemd/user/job-applier.service
@@ -9,6 +9,7 @@ ExecStart=/home/ervin/.local/bin/uv run python src/job_applier/cli/web_app.py --
 Restart=on-failure
 Environment=PATH=/home/ervin/.local/bin:/usr/local/bin:/usr/bin:/bin
 Environment=PYTHONUNBUFFERED=1
+Environment=JOB_APPLIER_DB_PATH=/home/ervin/prjs/job-applier/data/job_applier.db
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
## Summary

Pins the database file path for the `job-applier` user systemd service:

- Explicitly sets `Environment=JOB_APPLIER_DB_PATH=/home/ervin/prjs/job-applier/data/job_applier.db` in `dot_config/systemd/user/job-applier.service`.
- Prevents database resolution drift across varying working directories or execution environments, ensuring the web dashboard connects to the canonical SQLite database.

## Validation
- Verified `dot_config/systemd/user/job-applier.service` syntax.
- Branch is rebased cleanly on current `main` with zero drift.